### PR TITLE
Disablelkaonblinker

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -85,7 +85,7 @@ class CarController(object):
     if not lkas_active:
       apply_steer = 0
       
-    if CS.cstm_btns.get_button_status("lka") == 0:
+    if not CS.lane_departure_toggle_on:
         apply_steer = 0
     self.apply_steer_last = apply_steer
     

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -256,3 +256,12 @@ class CarState(object):
     self.lkas_car_model = cp_cam.vl["LKAS_HUD"]['CAR_MODEL']
     self.lkas_status_ok = cp_cam.vl["LKAS_HEARTBIT"]['LKAS_STATUS_OK']
     
+    if self.cstm_btns.get_button_status("lka") == 0:
+        self.lane_departure_toggle_on = False
+      else:
+        self.lane_departure_toggle_on = True
+
+    if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -257,9 +257,9 @@ class CarState(object):
     self.lkas_status_ok = cp_cam.vl["LKAS_HEARTBIT"]['LKAS_STATUS_OK']
     
     if self.cstm_btns.get_button_status("lka") == 0:
-        self.lane_departure_toggle_on = False
-      else:
-        self.lane_departure_toggle_on = True
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
 
     if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
       self.lane_departure_toggle_on = False

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -125,7 +125,7 @@ class CarController(object):
 
       self.apply_steer_last = apply_steer
       idx = (frame / P.STEER_STEP) % 4
-      if CS.lane_departure_toggle_on:
+      if not CS.lane_departure_toggle_on:
         apply_steer = 0
 
       if self.car_fingerprint in SUPERCRUISE_CARS:

--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -125,7 +125,7 @@ class CarController(object):
 
       self.apply_steer_last = apply_steer
       idx = (frame / P.STEER_STEP) % 4
-      if CS.cstm_btns.get_button_status("lka") == 0:
+      if CS.lane_departure_toggle_on:
         apply_steer = 0
 
       if self.car_fingerprint in SUPERCRUISE_CARS:

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -232,9 +232,9 @@ class CarState(object):
     self.right_blinker_on = pt_cp.vl["BCMTurnSignals"]['TurnSignals'] == 2
     
     if self.cstm_btns.get_button_status("lka") == 0:
-        self.lane_departure_toggle_on = False
-      else:
-        self.lane_departure_toggle_on = True
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
 
     if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
       self.lane_departure_toggle_on = False

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -230,7 +230,17 @@ class CarState(object):
     self.prev_right_blinker_on = self.right_blinker_on
     self.left_blinker_on = pt_cp.vl["BCMTurnSignals"]['TurnSignals'] == 1
     self.right_blinker_on = pt_cp.vl["BCMTurnSignals"]['TurnSignals'] == 2
+    
+    if self.cstm_btns.get_button_status("lka") == 0:
+        self.lane_departure_toggle_on = False
+      else:
+        self.lane_departure_toggle_on = True
 
+    if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
+      
     if self.car_fingerprint in SUPERCRUISE_CARS:
       self.park_brake = False
       self.main_on = False

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -171,10 +171,8 @@ class CarController(object):
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
     apply_steer = int(clip(-alca_steer * STEER_MAX, -STEER_MAX, STEER_MAX))
-    if CS.cstm_btns.get_button_status("lka") == 0:
-      apply_steer = 0
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
-    lkas_active = enabled and not CS.steer_not_allowed
+    lkas_active = enabled and not CS.steer_not_allowed and CS.lane_departure_toggle_on
 
     # Send CAN commands.
     can_sends = []

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -166,13 +166,14 @@ class CarController(object):
     # steer torque
     alca_angle, alca_steer, alca_enabled, turn_signal_needed = self.ALCA.update(enabled, CS, frame, actuators)
 
-
+    if not CS.lane_departure_toggle_on:
+      apply_steer = 0
     # steer torque is converted back to CAN reference (positive when steering right)
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
     apply_steer = int(clip(-alca_steer * STEER_MAX, -STEER_MAX, STEER_MAX))
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
-    lkas_active = enabled and not CS.steer_not_allowed and CS.lane_departure_toggle_on
+    lkas_active = enabled and not CS.steer_not_allowed and CS.lkMode
 
     # Send CAN commands.
     can_sends = []

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -166,12 +166,13 @@ class CarController(object):
     # steer torque
     alca_angle, alca_steer, alca_enabled, turn_signal_needed = self.ALCA.update(enabled, CS, frame, actuators)
 
-    if not CS.lane_departure_toggle_on:
-      apply_steer = 0
+
     # steer torque is converted back to CAN reference (positive when steering right)
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
     apply_steer = int(clip(-alca_steer * STEER_MAX, -STEER_MAX, STEER_MAX))
+    if not CS.lane_departure_toggle_on:
+      apply_steer = 0
     # any other cp.vl[0x18F]['STEER_STATUS'] is common and can happen during user override. sending 0 torque to avoid EPS sending error 5
     lkas_active = enabled and not CS.steer_not_allowed and CS.lkMode
 

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -150,6 +150,7 @@ def get_cam_can_parser(CP):
 
 class CarState(object):
   def __init__(self, CP):
+    self.lkMode = True
     self.kegman = kegman_conf()
     self.Angle = [0, 5, 10, 15,20,25,30,35,60,100,180,270,500]
     self.Angle_Speed = [255,160,100,80,70,60,55,50,40,30,20,10,5]
@@ -453,6 +454,13 @@ class CarState(object):
       if self.read_distance_lines == 3:
         self.UE.custom_alert_message(2,"Following distance set to 2.7s",200,3)
       self.read_distance_lines_prev = self.read_distance_lines
+    # when user presses LKAS button on steering wheel
+    if self.cruise_setting == 1:
+      if cp.vl["SCM_BUTTONS"]["CRUISE_SETTING"] == 0:
+        if self.lkMode:
+          self.lkMode = False
+        else:
+          self.lkMode = True
     if self.cstm_btns.get_button_status("lka") == 0:
         self.lane_departure_toggle_on = False
       else:

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -462,9 +462,9 @@ class CarState(object):
         else:
           self.lkMode = True
     if self.cstm_btns.get_button_status("lka") == 0:
-        self.lane_departure_toggle_on = False
-      else:
-        self.lane_departure_toggle_on = True
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
 
     if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
       self.lane_departure_toggle_on = False

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -453,7 +453,15 @@ class CarState(object):
       if self.read_distance_lines == 3:
         self.UE.custom_alert_message(2,"Following distance set to 2.7s",200,3)
       self.read_distance_lines_prev = self.read_distance_lines
+    if self.cstm_btns.get_button_status("lka") == 0:
+        self.lane_departure_toggle_on = False
+      else:
+        self.lane_departure_toggle_on = True
 
+    if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
     # Gets rid of Pedal Grinding noise when brake is pressed at slow speeds for some models
     # TODO: this should be ok for all cars. Verify it.
     if self.CP.carFingerprint in (CAR.PILOT, CAR.PILOT_2019, CAR.RIDGELINE):

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -408,7 +408,10 @@ class CarState(object):
         self.lane_departure_toggle_on = False
       else:
         self.lane_departure_toggle_on = True
-      
+    if self.alcaMode == 0 and (self.left_blinker_on or self.right_blinker_on):
+      self.lane_departure_toggle_on = False
+    else:
+      self.lane_departure_toggle_on = True
     self.distance_toggle = cp.vl["JOEL_ID"]['ACC_DISTANCE']
     if cp.vl["PCM_CRUISE_SM"]['DISTANCE_LINES'] == 2:
       self.trfix = True


### PR DESCRIPTION
Now that we can switch off alca. 
We can deactivate steering while the blinker is on so that you do not need to fight the model.