### PR TITLE
New kegman threading with automatic merging if file and conf variable mismatch

### DIFF
--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -4,7 +4,7 @@ from common.kalman.simple_kalman import KF1D
 from selfdrive.car.modules.UIBT_module import UIButtons,UIButton
 from selfdrive.car.modules.UIEV_module import UIEvents
 import numpy as np
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 
 
 def parse_gear_shifter(can_gear):
@@ -80,9 +80,8 @@ def get_camera_parser(CP):
 
 class CarState(object):
   def __init__(self, CP):
-    self.kegman = kegman_conf()
     self.alcaLabels = ["MadMax","Normal","Wifey","off"]
-    self.alcaMode = int(self.kegman.conf['lastALCAMode'])
+    self.alcaMode = int(kegman.conf['lastALCAMode'])
     self.prev_distance_button = 0
     self.distance_button = 0
     self.prev_lka_button = 0
@@ -172,10 +171,10 @@ class CarState(object):
       if (id == 1) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="alca":
           if self.cstm_btns.btns[id].btn_label2 == self.alcaLabels[self.alcaMode]:
             self.alcaMode = (self.alcaMode + 1 ) % 4
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           else:
             self.alcaMode = 0
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
           if self.alcaMode == 3:
@@ -187,7 +186,7 @@ class CarState(object):
         self.cstm_btns.btns[id].btn_status = btn_status
         if (id == 1) and self.cstm_btns.btns[id].btn_name=="alca":
           self.alcaMode = (self.alcaMode + 1 ) % 4
-          self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+          kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
     

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -11,7 +11,7 @@ from selfdrive.car.modules.UIEV_module import UIEvents
 from selfdrive.car.gm.values import DBC, CAR, parse_gear_shifter, \
                                     CruiseButtons, is_eps_status_ok, \
                                     STEER_THRESHOLD, SUPERCRUISE_CARS
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 
 def get_powertrain_can_parser(CP, canbus):
   # this function generates lists for signal, messages and initial values
@@ -59,11 +59,10 @@ def get_powertrain_can_parser(CP, canbus):
 
 class CarState(object):
   def __init__(self, CP, canbus):
-    self.kegman = kegman_conf()
     self.CP = CP
     # initialize can parser
     self.alcaLabels = ["MadMax","Normal","Wifey","off"]
-    self.alcaMode = int(self.kegman.conf['lastALCAMode'])     # default to last ALCAmode on startup
+    self.alcaMode = int(kegman.conf['lastALCAMode'])     # default to last ALCAmode on startup
     self.car_fingerprint = CP.carFingerprint
     self.cruise_buttons = CruiseButtons.UNPRESS
     self.prev_distance_button = 0
@@ -72,7 +71,7 @@ class CarState(object):
     self.prev_left_blinker_on = False
     self.right_blinker_on = False
     self.prev_right_blinker_on = False
-    self.follow_level = int(self.kegman.conf['lastTrMode'])
+    self.follow_level = int(kegman.conf['lastTrMode'])
     self.prev_lka_button = 0
     self.lka_button = 0
     self.lkMode = True
@@ -151,10 +150,10 @@ class CarState(object):
       if (id == 1) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="alca":
           if self.cstm_btns.btns[id].btn_label2 == self.alcaLabels[self.alcaMode]:
             self.alcaMode = (self.alcaMode + 1 ) % 4
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           else:
             self.alcaMode = 0
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
           if self.alcaMode == 3:
@@ -165,7 +164,7 @@ class CarState(object):
         self.cstm_btns.btns[id].btn_status = btn_status
         if (id == 1) and self.cstm_btns.btns[id].btn_name=="alca":
           self.alcaMode = (self.alcaMode + 1 ) % 4
-          self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last ALCAMode setting to file
+          kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
 

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -6,7 +6,7 @@ from selfdrive.controls.lib.drive_helpers import create_event, EventTypes as ET
 from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.car.gm.values import DBC, CAR, STOCK_CONTROL_MSGS, AUDIO_HUD, SUPERCRUISE_CARS
 from selfdrive.car.gm.carstate import CarState, CruiseButtons, get_powertrain_can_parser
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 
 try:
   from selfdrive.car.gm.carcontroller import CarController
@@ -22,8 +22,7 @@ class CanBus(object):
 
 class CarInterface(object):
   def __init__(self, CP, sendcan=None):
-    self.kegman = kegman_conf()
-    self.angleSteersoffset = float(self.kegman.conf['angle_steers_offset'])  # deg offset
+    self.angleSteersoffset = float(kegman.conf['angle_steers_offset'])  # deg offset
     self.CP = CP
     self.frame = 0
     self.gas_pressed_prev = False
@@ -305,7 +304,7 @@ class CarInterface(object):
       self.CS.follow_level -= 1
       if self.CS.follow_level < 1:
         self.CS.follow_level = 3
-      self.kegman.conf['lastTrMode'] = str(self.CS.follow_level)   # write last distance bar setting to file
+      kegman.save({'lastTrMode': str(self.CS.follow_level)})  # write last distance bar setting to file
     ret.gasbuttonstatus = self.CS.cstm_btns.get_button_status("gas")
     events = []
     if not self.CS.can_valid:

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -8,9 +8,7 @@ from selfdrive.car.honda import hondacan
 from selfdrive.car.honda.values import AH, CruiseButtons, CAR
 from selfdrive.can.packer import CANPacker
 from selfdrive.car.modules.ALCA_module import ALCAController
-from selfdrive.kegman_conf import kegman_conf
-
-kegman = kegman_conf(read_only=True)
+import selfdrive.kegman_conf as kegman
 
 def actuator_hystereses(brake, braking, brake_steady, v_ego, car_fingerprint):
   # hyst params

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -3,7 +3,7 @@ from common.kalman.simple_kalman import KF1D
 from selfdrive.can.parser import CANParser, CANDefine
 from selfdrive.config import Conversions as CV
 from selfdrive.car.honda.values import CAR, DBC, STEER_THRESHOLD, SPEED_FACTOR, HONDA_BOSCH
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 from selfdrive.car.modules.UIBT_module import UIButtons,UIButton
 from selfdrive.car.modules.UIEV_module import UIEvents
 import numpy as np
@@ -150,21 +150,20 @@ def get_cam_can_parser(CP):
 
 class CarState(object):
   def __init__(self, CP):
-    self.kegman = kegman_conf()
     self.Angle = [0, 5, 10, 15,20,25,30,35,60,100,180,270,500]
     self.Angle_Speed = [255,160,100,80,70,60,55,50,40,30,20,10,5]
     self.blind_spot_on = bool(0)
     #labels for ALCA modes
     self.alcaLabels = ["MadMax","Normal","Wifey","off"]
     self.trLabels = ["0.9","dyn","2.7"]
-    self.alcaMode = int(self.kegman.conf['lastALCAMode'])     # default to last ALCA Mode on startup
+    self.alcaMode = int(kegman.conf['lastALCAMode'])     # default to last ALCA Mode on startup
     if self.alcaMode > 3:
       self.alcaMode = 3
-      self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
-    self.trMode = int(self.kegman.conf['lastTrMode'])     # default to last distance interval on startup
+      kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
+    self.trMode = int(kegman.conf['lastTrMode'])     # default to last distance interval on startup
     if self.trMode > 2:
       self.trMode = 2
-      self.kegman.conf['lastTrMode'] = str(self.trMode)   # write last distance bar setting to file
+      kegman.save({'lastTrMode': str(self.trMode)})  # write last distance bar setting to file
     #if (CP.carFingerprint == CAR.MODELS):
     # ALCA PARAMS
     # max REAL delta angle for correction vs actuator
@@ -263,10 +262,10 @@ class CarState(object):
       if (id == 0) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="alca":
           if self.cstm_btns.btns[id].btn_label2 == self.alcaLabels[self.alcaMode]:
             self.alcaMode = (self.alcaMode + 1 ) % 4
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           else:
             self.alcaMode = 0
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last distance bar setting to file
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
           if self.alcaMode == 3:
@@ -275,10 +274,10 @@ class CarState(object):
       elif (id == 4) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="tr":
           if self.cstm_btns.btns[id].btn_label2 == self.trLabels[self.trMode]:
             self.trMode = (self.trMode + 1 ) % 3
-            self.kegman.conf['lastTrMode'] = str(self.trMode)   # write last distance bar setting to file
+            kegman.save({'lastTrMode': str(self.trMode)})  # write last distance bar setting to file
           else:
             self.trMode = 0
-            self.kegman.conf['lastTrMode'] = str(self.trMode)   # write last distance bar setting to file
+            kegman.save({'lastTrMode': str(self.trMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.trLabels[self.trMode]
           self.cstm_btns.hasChanges = True
 
@@ -288,7 +287,7 @@ class CarState(object):
         self.cstm_btns.btns[id].btn_status = btn_status
         if (id == 0) and self.cstm_btns.btns[id].btn_name=="alca":
           self.alcaMode = (self.alcaMode + 1 ) % 4
-          self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last ALCAMode setting to file
+          kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last distance bar setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
 
@@ -432,7 +431,7 @@ class CarState(object):
     if self.cruise_setting == 3:
       if cp.vl["SCM_BUTTONS"]["CRUISE_SETTING"] == 0:
         self.trMode = (self.trMode + 1 ) % 3
-        self.kegman.conf['lastTrMode'] = str(self.trMode)   # write last distance bar setting to file
+        kegman.save({'lastTrMode': str(self.trMode)})  # write last distance bar setting to file
         self.cstm_btns.btns[4].btn_label2 = self.trLabels[self.trMode]
     self.prev_cruise_setting = self.cruise_setting
     self.cruise_setting = cp.vl["SCM_BUTTONS"]['CRUISE_SETTING']

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -11,9 +11,7 @@ from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.car.honda.carstate import CarState, get_can_parser, get_cam_can_parser
 from selfdrive.car.honda.values import CruiseButtons, CAR, HONDA_BOSCH, AUDIO_HUD, VISUAL_HUD
 from selfdrive.controls.lib.planner import _A_CRUISE_MAX_V_FOLLOWING
-from selfdrive.kegman_conf import kegman_conf
-
-kegman = kegman_conf(read_only=True)
+import selfdrive.kegman_conf as kegman
 
 angleSteersoffset = float(kegman.conf['angle_steers_offset'])  # deg offset
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -9,7 +9,7 @@ from selfdrive.can.parser import CANParser, CANDefine
 from selfdrive.config import Conversions as CV
 from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD
 from common.kalman.simple_kalman import KF1D
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 from selfdrive.car.modules.UIBT_module import UIButtons,UIButton
 from selfdrive.car.modules.UIEV_module import UIEvents
 import os
@@ -147,8 +147,7 @@ def get_cam_can_parser(CP):
 
 class CarState(object):
   def __init__(self, CP):
-    self.kegman = kegman_conf()
-    self.brakefactor = float(self.kegman.conf['brakefactor'])
+    self.brakefactor = float(kegman.conf['brakefactor'])
     self.trfix = False
     self.Angles = np.zeros(250)
     self.Angles_later = np.zeros(250)
@@ -156,13 +155,13 @@ class CarState(object):
     self.Angle = [0, 5, 10, 15,20,25,30,35,60,100,180,270,500]
     self.Angle_Speed = [255,160,100,80,70,60,55,50,40,33,27,17,12]
     #labels for gas mode
-    self.gasMode = int(self.kegman.conf['lastGasMode'])
-    self.sloMode = int(self.kegman.conf['lastSloMode'])
+    self.gasMode = int(kegman.conf['lastGasMode'])
+    self.sloMode = int(kegman.conf['lastSloMode'])
     self.sloLabels = ["offset","normal"]
     self.gasLabels = ["dynamic","sport","eco"]
     #labelslabels for ALCA modes
     self.alcaLabels = ["MadMax","Normal","Wifey","off"]
-    self.alcaMode = int(self.kegman.conf['lastALCAMode'])     # default to last ALCAmode on startup
+    self.alcaMode = int(kegman.conf['lastALCAMode'])     # default to last ALCAmode on startup
     #if (CP.carFingerprint == CAR.MODELS):
     # ALCA PARAMS
     # max REAL delta angle for correction vs actuator
@@ -268,12 +267,10 @@ class CarState(object):
       if (id == 1) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="alca":
           if self.cstm_btns.btns[id].btn_label2 == self.alcaLabels[self.alcaMode]:
             self.alcaMode = (self.alcaMode + 1 ) % 4
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last ALCAMode setting to file
-            self.kegman.write_config(self.kegman.conf)
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last ALCAMode setting to file
           else:
             self.alcaMode = 0
-            self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last ALCAMode setting to file
-            self.kegman.write_config(self.kegman.conf)
+            kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last ALCAMode setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
           if self.alcaMode == 3:
@@ -281,12 +278,10 @@ class CarState(object):
       elif (id == 2) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="slow":
         if self.cstm_btns.btns[id].btn_label2 == self.sloLabels[self.sloMode]:
           self.sloMode = (self.sloMode + 1 ) % 2
-          self.kegman.conf['lastSloMode'] = str(self.sloMode)   # write last SloMode setting to file
-          self.kegman.write_config(self.kegman.conf)
+          kegman.save({'lastSloMode': str(self.sloMode)})  # write last SloMode setting to file
         else:
           self.sloMode = 0
-          self.kegman.conf['lastSloMode'] = str(self.sloMode)   # write last SloMode setting to file
-          self.kegman.write_config(self.kegman.conf)
+          kegman.save({'lastSloMode': str(self.sloMode)})  # write last SloMode setting to file
         self.cstm_btns.btns[id].btn_label2 = self.sloLabels[self.sloMode]
         self.cstm_btns.hasChanges = True
         if self.sloMode == 0:
@@ -294,12 +289,10 @@ class CarState(object):
       elif (id == 5) and (btn_status == 0) and self.cstm_btns.btns[id].btn_name=="gas":
           if self.cstm_btns.btns[id].btn_label2 == self.gasLabels[self.gasMode]:
             self.gasMode = (self.gasMode + 1 ) % 3
-            self.kegman.conf['lastGasMode'] = str(self.gasMode)   # write last GasMode setting to file
-            self.kegman.write_config(self.kegman.conf)
+            kegman.save({'lastGasMode': str(self.gasMode)})  # write last GasMode setting to file
           else:
             self.gasMode = 0
-            self.kegman.conf['lastGasMode'] = str(self.gasMode)   # write last GasMode setting to file
-            self.kegman.write_config(self.kegman.conf)
+            kegman.save({'lastGasMode': str(self.gasMode)})  # write last GasMode setting to file
 
           self.cstm_btns.btns[id].btn_label2 = self.gasLabels[self.gasMode]
           self.cstm_btns.hasChanges = True
@@ -309,14 +302,12 @@ class CarState(object):
         self.cstm_btns.btns[id].btn_status = btn_status
         if (id == 1) and self.cstm_btns.btns[id].btn_name=="alca":
           self.alcaMode = (self.alcaMode + 1 ) % 4
-          self.kegman.conf['lastALCAMode'] = str(self.alcaMode)   # write last ALCAMode setting to file
-          self.kegman.write_config(self.kegman.conf)
+          kegman.save({'lastALCAMode': str(self.alcaMode)})  # write last ALCAMode setting to file
           self.cstm_btns.btns[id].btn_label2 = self.alcaLabels[self.alcaMode]
           self.cstm_btns.hasChanges = True
         elif (id == 2) and self.cstm_btns.btns[id].btn_name=="slow":
           self.sloMode = (self.sloMode + 1 ) % 2
-          self.kegman.conf['lastSloMode'] = str(self.sloMode)   # write last SloMode setting to file
-          self.kegman.write_config(self.kegman.conf)
+          kegman.save({'lastSloMode': str(self.sloMode)})  # write last SloMode setting to file
           self.cstm_btns.btns[id].btn_label2 = self.sloLabels[self.sloMode]
           self.cstm_btns.hasChanges = True
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -7,10 +7,7 @@ from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.car.toyota.carstate import CarState, get_can_parser, get_cam_can_parser
 from selfdrive.car.toyota.values import ECU, check_ecu_msgs, CAR
 from selfdrive.swaglog import cloudlog
-
-from selfdrive.kegman_conf import kegman_conf
-
-kegman = kegman_conf()
+import selfdrive.kegman_conf as kegman
 
 steeringAngleoffset = float(kegman.conf['angle_steers_offset'])  # deg offset
    

--- a/selfdrive/controls/lib/driver_monitor.py
+++ b/selfdrive/controls/lib/driver_monitor.py
@@ -2,9 +2,7 @@ import numpy as np
 from common.realtime import sec_since_boot
 from selfdrive.controls.lib.drive_helpers import create_event, EventTypes as ET
 from common.filter_simple import FirstOrderFilter
-from selfdrive.kegman_conf import kegman_conf
-
-kegman = kegman_conf(read_only=True)
+import selfdrive.kegman_conf as kegman
 
 _DT = 0.01                  # update runs at 100Hz
 _DTM = 0.1                  # DM runs at 10Hz

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -2,11 +2,10 @@ import zmq
 from cereal import log
 from common.numpy_fast import clip, interp
 from selfdrive.controls.lib.pid import PIController
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 import selfdrive.messaging as messaging
 from selfdrive.services import service_list
 
-kegman = kegman_conf(read_only=True)
 LongCtrlState = log.Live100Data.LongControlState
 
 STOPPING_EGO_SPEED = 0.5

--- a/selfdrive/controls/lib/model_parser.py
+++ b/selfdrive/controls/lib/model_parser.py
@@ -1,8 +1,7 @@
 from common.numpy_fast import interp
 from selfdrive.controls.lib.latcontrol_helpers import model_polyfit, calc_desired_path, compute_path_pinv
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 
-kegman = kegman_conf()
 CAMERA_OFFSET = float(kegman.conf['cameraOffset'])  # m from center car to camera
 
 

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -15,9 +15,7 @@ from selfdrive.controls.lib.longcontrol import LongCtrlState, MIN_CAN_SPEED
 from selfdrive.controls.lib.fcw import FCWChecker
 from selfdrive.controls.lib.long_mpc import LongitudinalMpc
 
-from selfdrive.kegman_conf import kegman_conf
-
-kegman = kegman_conf()
+import selfdrive.kegman_conf as kegman
 
 NO_CURVATURE_SPEED = 200. * CV.MPH_TO_MS
 
@@ -38,7 +36,7 @@ _A_CRUISE_MAX_V_FOLLOWING = [1.6, 1.6, 1.2, .7, .3]
 _A_CRUISE_MAX_BP = [0.,  5., 10., 20., 40.]
 
 # Lookup table for turns
-_brake_factor = float(kegman.conf['brakefactor'])
+_brake_factor = float(kegman.get("brakefactor"))
 _A_TOTAL_MAX_V = [2.0 * _brake_factor, 2.7 * _brake_factor, 3.5 * _brake_factor]
 _A_TOTAL_MAX_BP = [0., 25., 40.]
 

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -57,27 +57,33 @@ def read_config():
 def kegman_thread():  # read and write thread; now merges changes from file and variable
   global conf
   global variables_written
+  global thread_started
   last_conf = copy.deepcopy(conf)
-  while True:
-    time.sleep(30)  # every n seconds check for conf change
-    with open(kegman_file, "r") as f:
-      conf_tmp = json.load(f)
-    if conf != last_conf or conf != conf_tmp:  # if either variable or file has changed
-      if conf_tmp != conf:  # if change in file
-        changed_keys = []
-        for i in conf_tmp:
-          try:
-            if conf_tmp[i] != conf[i]:
+  try:
+    while True:
+      time.sleep(30)  # every n seconds check for conf change
+      with open(kegman_file, "r") as f:
+        conf_tmp = json.load(f)
+      if conf != last_conf or conf != conf_tmp:  # if either variable or file has changed
+        if conf_tmp != conf:  # if change in file
+          changed_keys = []
+          for i in conf_tmp:
+            try:
+              if conf_tmp[i] != conf[i]:
+                changed_keys.append(i)
+            except:  # if new param from file not existing in variable
               changed_keys.append(i)
-          except:  # if new param from file not existing in variable
-            changed_keys.append(i)
-        for i in changed_keys:
-          if i not in variables_written:
-            conf.update({i: conf_tmp[i]})
-      if conf != conf_tmp:
-        write_config(conf)
-      last_conf = copy.deepcopy(conf)
-    variables_written = []
+          for i in changed_keys:
+            if i not in variables_written:
+              conf.update({i: conf_tmp[i]})
+        if conf != conf_tmp:
+          write_config(conf)
+        last_conf = copy.deepcopy(conf)
+      variables_written = []
+  except:
+    print("Error in kegman thread!")
+    cloudlog.exception("error in kegman thread")
+    thread_started = False
 
 def write_config(conf):  # never to be called outside kegman_conf
   try:

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -54,7 +54,6 @@ def read_config():
     config = default_config
   return config
 
-
 def kegman_thread():  # read and write thread; now merges changes from file and variable
   global conf
   global variables_written
@@ -80,7 +79,6 @@ def kegman_thread():  # read and write thread; now merges changes from file and 
       last_conf = copy.deepcopy(conf)
     variables_written = []
 
-
 def write_config(conf):  # never to be called outside kegman_conf
   try:
     with open(kegman_file, "w") as f:
@@ -91,7 +89,6 @@ def write_config(conf):  # never to be called outside kegman_conf
     with open(kegman_file, "w") as f:
       json.dump(conf, f, indent=2, sort_keys=True)
       os.chmod(kegman_file, 0o764)
-
 
 def save(data):  # allows for writing multiple key/value pairs
   global conf
@@ -104,7 +101,6 @@ def save(data):  # allows for writing multiple key/value pairs
   for key in data:
     variables_written.append(key)
   conf.update(data)
-
 
 def get(key_s):  # can get multiple keys from a list
   if type(key_s) == list:

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -6,10 +6,15 @@ import time
 from selfdrive.swaglog import cloudlog
 from common.basedir import BASEDIR
 
+conf = {}
+
 class kegman_conf():
+  global conf
   conf = {"lastGasMode": "0"}
   def __init__(self, read_only=False):  # start thread by default
-    self.conf = self.read_config()
+    #self.conf = self.read_config()
+    global conf
+    conf = {"lastGasMode": "0"}
     # when you import kegman_conf and only use it to read data, you can specify read_only in your import as to not start the write_thread
     if not read_only and BASEDIR == "/data/openpilot":  # if not travis test nor read only
       threading.Thread(target=self.kegman_thread).start()

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -6,92 +6,115 @@ import time
 from selfdrive.swaglog import cloudlog
 from common.basedir import BASEDIR
 
-conf = {}
+def read_config():
+  default_config = {"cameraOffset": "0.06", "lastTrMode": "1", "battChargeMin": "90", "battChargeMax": "95",
+                    "wheelTouchSeconds": "1800", "battPercOff": "25", "carVoltageMinEonShutdown": "11200",
+                    "brakeStoppingTarget": "0.25", "angle_steers_offset": "0", "brake_distance_extra": "1",
+                    "lastALCAMode": "1", "brakefactor": "1.2", "lastGasMode": "0", "lastSloMode": "1",
+                    "leadDistance": "5"}
 
-class kegman_conf():
-  def __init__(self, read_only=False):  # start thread by default
-    #self.conf = self.read_config()
-    global conf
-    conf = {"lastGasMode": "0"}
-    # when you import kegman_conf and only use it to read data, you can specify read_only in your import as to not start the write_thread
-    if not read_only and BASEDIR == "/data/openpilot":  # if not travis test nor read only
-      threading.Thread(target=self.kegman_thread).start()
+  if os.path.isfile(kegman_file):
+    with open(kegman_file, "r") as f:
+      try:
+        config = json.load(f)
+      except:
+        cloudlog.exception("reading kegman.json error")
+        config = default_config
+    if "battPercOff" not in config:
+      config.update({"battPercOff": "25"})
+    if "carVoltageMinEonShutdown" not in config:
+      config.update({"carVoltageMinEonShutdown": "11200"})
+    if "brakeStoppingTarget" not in config:
+      config.update({"brakeStoppingTarget": "0.25"})
+    if "angle_steers_offset" not in config:
+      config.update({"angle_steers_offset": "0"})
+    if "brake_distance_extra" not in config:  # extra braking distance in m
+      config.update({"brake_distance_extra": "1"})
+    if "lastALCAMode" not in config:
+      config.update({"lastALCAMode": "1"})
+    if "brakefactor" not in config:  # brake at 20% higher speeds than what I like
+      config.update({"brakefactor": "1.2"})
+    if "lastGasMode" not in config:
+      config.update({"lastGasMode": "0"})
+    if "lastSloMode" not in config:
+      config.update({"lastSloMode": "1"})
+    if "leadDistance" not in config:  # leadDistance only works for Accord and Insight, have not tested other honda vehicles
+      config.update({"leadDistance": "5.0"})
 
-  def read_config(self):
-    default_config = {"cameraOffset":"0.06", "lastTrMode":"1", "battChargeMin":"90", "battChargeMax":"95", "wheelTouchSeconds":"1800", "battPercOff":"25", "carVoltageMinEonShutdown":"11200", "brakeStoppingTarget":"0.25", "angle_steers_offset":"0" , "brake_distance_extra":"1" , "lastALCAMode":"1" , "brakefactor":"1.2", "lastGasMode":"0" , "lastSloMode":"1", "leadDistance":"5"}
+    # force update
+    if config["carVoltageMinEonShutdown"] == "11800":
+      config.update({"carVoltageMinEonShutdown": "11200"})
+    if int(config["wheelTouchSeconds"]) < 200:
+      config.update({"wheelTouchSeconds": "1800"})
+    if int(config["battChargeMin"]) == 85:
+      config.update({"battChargeMin": "90"})
+    if int(config["battChargeMax"]) == 90:
+      config.update({"battChargeMax": "95"})
+  else:
+    config = default_config
+  return config
 
-    if os.path.isfile('/data/kegman.json'):
-      with open('/data/kegman.json', 'r') as f:
-        try:
-          config = json.load(f)
-        except:
-          cloudlog.exception("reading kegman.json error")
-          config = default_config
-      self.last_conf = copy.deepcopy(config)
-      if "battPercOff" not in config:
-        config.update({"battPercOff":"25"})
-      if "carVoltageMinEonShutdown" not in config:
-        config.update({"carVoltageMinEonShutdown":"11200"})
-      if "brakeStoppingTarget" not in config:
-        config.update({"brakeStoppingTarget":"0.25"})
-      if "angle_steers_offset" not in config:
-        config.update({"angle_steers_offset":"0"})
-      if "brake_distance_extra" not in config: # extra braking distance in m
-        config.update({"brake_distance_extra":"1"})
-      if "lastALCAMode" not in config:
-        config.update({"lastALCAMode":"1"})
-      if "brakefactor" not in config: # brake at 20% higher speeds than what I like
-        config.update({"brakefactor":"1.2"})
-      if "lastGasMode" not in config:
-        config.update({"lastGasMode":"0"})
-      if "lastSloMode" not in config:
-        config.update({"lastSloMode":"1"})
-      if "leadDistance" not in config: # leadDistance only works for Accord and Insight, have not tested other honda vehicles
-        config.update({"leadDistance":"5.0"})
 
-      # force update
-      if config['carVoltageMinEonShutdown'] == "11800":
-        config.update({"carVoltageMinEonShutdown":"11200"})
-      if int(config['wheelTouchSeconds']) < 200:
-        config.update({"wheelTouchSeconds":"1800"})
-      if int(config['battChargeMin']) == 85:
-        config.update({"battChargeMin":"90"})
-      if int(config['battChargeMax']) == 90:
-        config.update({"battChargeMax":"95"})
-    else:
-      config = default_config
-    return config
+def kegman_thread():  # read and write thread; now merges changes from file and variable
+  global conf
+  global variables_written
+  last_conf = copy.deepcopy(conf)
+  while True:
+    time.sleep(30)  # every n seconds check for conf change
+    with open(kegman_file, "r") as f:
+      conf_tmp = json.load(f)
+    if conf != last_conf or conf != conf_tmp:  # if either variable or file has changed
+      if conf_tmp != conf:  # if change in file
+        changed_keys = []
+        for i in conf_tmp:
+          try:
+            if conf_tmp[i] != conf[i]:
+              changed_keys.append(i)
+          except:  # if new param from file not existing in variable
+            changed_keys.append(i)
+        for i in changed_keys:
+          if i not in variables_written:
+            conf.update({i: conf_tmp[i]})
+      if conf != conf_tmp:
+        write_config(conf)
+      last_conf = copy.deepcopy(conf)
+    variables_written = []
 
-  def kegman_thread(self):  # do reading and writing in one thread
-    global conf
-    last_conf = copy.deepcopy(conf)
-    change_from_file = False
-    write_to_file = False
-    while True:
-      if conf != last_conf and not change_from_file:
-        self.write_config(conf)
-        last_conf = copy.deepcopy(conf)  # cache the current config
-        write_to_file = True
-      else:
-        change_from_file = False
-        last_conf = copy.deepcopy(conf)
-      time.sleep(15)  # every n seconds check for conf change
-      with open('/data/kegman.json', 'r') as f:
-        conf_tmp = json.load(f)
-        if conf_tmp != conf and not write_to_file:
-          change_from_file = True
-          conf = conf_tmp
-          last_conf = copy.deepcopy(conf)
-        else:
-          write_to_file = False
 
-  def write_config(self, conf):  # never to be called outside kegman_conf
-    try:
-      with open('/data/kegman.json', 'w') as f:
-        json.dump(conf, f, indent=2, sort_keys=True)
-        os.chmod("/data/kegman.json", 0o764)
-    except IOError:
-      os.mkdir('/data')
-      with open('/data/kegman.json', 'w') as f:
-        json.dump(conf, f, indent=2, sort_keys=True)
-        os.chmod("/data/kegman.json", 0o764)
+def write_config(conf):  # never to be called outside kegman_conf
+  try:
+    with open(kegman_file, "w") as f:
+      json.dump(conf, f, indent=2, sort_keys=True)
+      os.chmod(kegman_file, 0o764)
+  except IOError:
+    os.mkdir("/data")
+    with open(kegman_file, "w") as f:
+      json.dump(conf, f, indent=2, sort_keys=True)
+      os.chmod(kegman_file, 0o764)
+
+
+def save(data):  # allows for writing multiple key/value pairs
+  global conf
+  global thread_started
+  global variables_written
+  if not thread_started and BASEDIR == "/data/openpilot":
+    threading.Thread(target=kegman_thread).start()  # automatically start write thread if file needs it
+    thread_started = True
+    print("Starting thread!")
+  for key in data:
+    variables_written.append(key)
+  conf.update(data)
+
+
+def get(key_s):  # can get multiple keys from a list
+  if type(key_s) == list:
+    return [conf[i] if i in conf else None for i in key_s]
+  if key_s in conf:
+    return conf[key_s]
+  else:
+    return None
+
+thread_started = False
+kegman_file = "/data/kegman.json"
+variables_written = []
+conf = read_config()

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -60,16 +60,25 @@ class kegman_conf():
 
   def kegman_thread(self):  # do reading and writing in one thread
     last_conf = copy.deepcopy(self.conf)
+    change_from_file = False
+    write_to_file = False
     while True:
-      if self.conf != last_conf:
+      if self.conf != last_conf and not change_from_file:
         self.write_config()
         last_conf = copy.deepcopy(self.conf)  # cache the current config
+        write_to_file = True
+      else:
+        change_from_file = False
+        last_conf = copy.deepcopy(self.conf)
       time.sleep(15)  # every n seconds check for conf change
       with open('/data/kegman.json', 'r') as f:
         conf_tmp = json.load(f)
-        if conf_tmp != self.conf:
+        if conf_tmp != self.conf and not write_to_file:
+          change_from_file = True
           self.conf = conf_tmp
           last_conf = copy.deepcopy(self.conf)
+        else:
+          write_to_file = False
 
   def write_config(self):  # never to be called outside kegman_conf
     try:

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -9,8 +9,6 @@ from common.basedir import BASEDIR
 conf = {}
 
 class kegman_conf():
-  global conf
-  conf = {"lastGasMode": "0"}
   def __init__(self, read_only=False):  # start thread by default
     #self.conf = self.read_config()
     global conf
@@ -65,24 +63,25 @@ class kegman_conf():
     return config
 
   def kegman_thread(self):  # do reading and writing in one thread
-    last_conf = copy.deepcopy(kegman_conf.conf)
+    global conf
+    last_conf = copy.deepcopy(conf)
     change_from_file = False
     write_to_file = False
     while True:
-      if kegman_conf.conf != last_conf and not change_from_file:
-        self.write_config(kegman_conf.conf)
-        last_conf = copy.deepcopy(kegman_conf.conf)  # cache the current config
+      if conf != last_conf and not change_from_file:
+        self.write_config(conf)
+        last_conf = copy.deepcopy(conf)  # cache the current config
         write_to_file = True
       else:
         change_from_file = False
-        last_conf = copy.deepcopy(kegman_conf.conf)
+        last_conf = copy.deepcopy(conf)
       time.sleep(15)  # every n seconds check for conf change
       with open('/data/kegman.json', 'r') as f:
         conf_tmp = json.load(f)
-        if conf_tmp != kegman_conf.conf and not write_to_file:
+        if conf_tmp != conf and not write_to_file:
           change_from_file = True
-          kegman_conf.conf = conf_tmp
-          last_conf = copy.deepcopy(kegman_conf.conf)
+          conf = conf_tmp
+          last_conf = copy.deepcopy(conf)
         else:
           write_to_file = False
 

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -7,6 +7,7 @@ from selfdrive.swaglog import cloudlog
 from common.basedir import BASEDIR
 
 class kegman_conf():
+  conf = {"lastGasMode": "0"}
   def __init__(self, read_only=False):  # start thread by default
     self.conf = self.read_config()
     # when you import kegman_conf and only use it to read data, you can specify read_only in your import as to not start the write_thread

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -59,34 +59,34 @@ class kegman_conf():
     return config
 
   def kegman_thread(self):  # do reading and writing in one thread
-    last_conf = copy.deepcopy(self.conf)
+    last_conf = copy.deepcopy(kegman_conf.conf)
     change_from_file = False
     write_to_file = False
     while True:
-      if self.conf != last_conf and not change_from_file:
-        self.write_config()
-        last_conf = copy.deepcopy(self.conf)  # cache the current config
+      if kegman_conf.conf != last_conf and not change_from_file:
+        self.write_config(kegman_conf.conf)
+        last_conf = copy.deepcopy(kegman_conf.conf)  # cache the current config
         write_to_file = True
       else:
         change_from_file = False
-        last_conf = copy.deepcopy(self.conf)
+        last_conf = copy.deepcopy(kegman_conf.conf)
       time.sleep(15)  # every n seconds check for conf change
       with open('/data/kegman.json', 'r') as f:
         conf_tmp = json.load(f)
-        if conf_tmp != self.conf and not write_to_file:
+        if conf_tmp != kegman_conf.conf and not write_to_file:
           change_from_file = True
-          self.conf = conf_tmp
-          last_conf = copy.deepcopy(self.conf)
+          kegman_conf.conf = conf_tmp
+          last_conf = copy.deepcopy(kegman_conf.conf)
         else:
           write_to_file = False
 
-  def write_config(self):  # never to be called outside kegman_conf
+  def write_config(self, conf):  # never to be called outside kegman_conf
     try:
       with open('/data/kegman.json', 'w') as f:
-        json.dump(self.conf, f, indent=2, sort_keys=True)
+        json.dump(conf, f, indent=2, sort_keys=True)
         os.chmod("/data/kegman.json", 0o764)
     except IOError:
       os.mkdir('/data')
       with open('/data/kegman.json', 'w') as f:
-        json.dump(self.conf, f, indent=2, sort_keys=True)
+        json.dump(conf, f, indent=2, sort_keys=True)
         os.chmod("/data/kegman.json", 0o764)

--- a/selfdrive/thermald.py
+++ b/selfdrive/thermald.py
@@ -12,11 +12,10 @@ from common.params import Params
 from common.realtime import sec_since_boot
 from common.numpy_fast import clip
 from common.filter_simple import FirstOrderFilter
-from selfdrive.kegman_conf import kegman_conf
+import selfdrive.kegman_conf as kegman
 import subprocess
 import signal
 
-kegman = kegman_conf(read_only=True)
 ThermalStatus = log.ThermalData.ThermalStatus
 CURRENT_TAU = 2.   # 2s time constant
 
@@ -116,7 +115,7 @@ def check_car_battery_voltage(should_start, health, charging_disabled, msg):
   #   - 12V battery voltage is too low, and;
   #   - onroad isn't started
   print health
-  
+
   if charging_disabled and (health is None or health.health.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+400)) and msg.thermal.batteryPercent < int(kegman.conf['battChargeMin']):
     charging_disabled = False
     os.system('echo "1" > /sys/class/power_supply/battery/charging_enabled')


### PR DESCRIPTION
Also automatically launches the write thread if the file saves a parameter

New syntax to get values (note, the old syntax still works):
`kegman.get("lastSloMode")`
Can also supply a list of keys:
`kegman.get(["lastSloMode", "lastGasMode"])`

New syntax to save key/value (the old syntax does *not* work):
`kegman.save({"wheelTouchSeconds": 600})`
Can also supply multiple key/value pairs to save at once:
`kegman.save({"wheelTouchSeconds": 600, "lastALCAMode": 2})`

New syntax to import:
`import selfdrive.kegman_conf as kegman`

Calling `kegman = kegman_conf()` is no longer required.