### PR TITLE
Fix pathplanner delta and model bias

### DIFF
--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -77,12 +77,12 @@ class CarInterface(object):
     ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15,0.30], [0.03,0.05]]
     ret.lateralTuning.pid.kf = 0.00006   # full torque for 10 deg at 80mph means 0.00007818594
     ret.steerActuatorDelay = 0.1
-    ret.steerRateCost = 0.7
+    ret.steerRateCost = 0.15
 
     if candidate in (CAR.JEEP_CHEROKEE_2017, CAR.JEEP_CHEROKEE_2018, CAR.JEEP_CHEROKEE_2019):
       ret.wheelbase = 2.91  # in meters
       ret.steerRatio = 11.6 # 0.5.10
-      ret.steerActuatorDelay = 0.2  # in seconds
+      ret.steerActuatorDelay = 0.1  # in seconds
 
     ret.centerToFront = ret.wheelbase * 0.44
 
@@ -185,7 +185,7 @@ class CarInterface(object):
     # ignore standstill in hybrid rav4, since pcm allows to restart without
     # receiving any special command
     ret.cruiseState.standstill = False
-    
+
     ret.readdistancelines = 1
     ret.genericToggle = False
     ret.laneDepartureToggle = False
@@ -224,7 +224,7 @@ class CarInterface(object):
       disengage_event = True
     else:
       disengage_event = False
-    
+
     ret.gasbuttonstatus = self.CS.gasMode
     # events
     events = []

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -200,7 +200,7 @@ class CarInterface(object):
     ret.startAccel = 0.0
 
     ret.steerActuatorDelay = 0.1  # Default delay, not measured yet
-    ret.steerRateCost = 1.0
+    ret.steerRateCost = 0.15
     ret.steerControlType = car.CarParams.SteerControlType.torque
 
     return ret
@@ -298,13 +298,13 @@ class CarInterface(object):
       buttonEvents.append(be)
 
     ret.buttonEvents = buttonEvents
-    
+
     if self.CS.lka_button and self.CS.lka_button != self.CS.prev_lka_button:
       if self.CS.lkMode:
         self.CS.lkMode = False
       else:
         self.CS.lkMode = True
-        
+
     if self.CS.distance_button and self.CS.distance_button != self.CS.prev_distance_button:
       self.CS.follow_level -= 1
       if self.CS.follow_level < 1:

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -394,7 +394,7 @@ class CarInterface(object):
     ret.startAccel = 0.5
 
     ret.steerActuatorDelay = 0.1
-    ret.steerRateCost = 0.5
+    ret.steerRateCost = 0.2
 
     return ret
 
@@ -453,7 +453,7 @@ class CarInterface(object):
     ret.cruiseState.available = bool(self.CS.main_on)
     ret.cruiseState.speedOffset = self.CS.cruise_speed_offset
     ret.cruiseState.standstill = False
-    
+
     ret.readdistancelines = self.CS.read_distance_lines
 
     # TODO: button presses

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -71,7 +71,7 @@ class CarInterface(object):
     tire_stiffness_factor = 1.
 
     ret.steerActuatorDelay = 0.1  # Default delay
-    ret.steerRateCost = 0.5
+    ret.steerRateCost = 0.2
 
     if candidate == CAR.SANTA_FE:
       ret.lateralTuning.pid.kf = 0.00005
@@ -202,7 +202,7 @@ class CarInterface(object):
       ret.gearShifter = self.CS.gear_tcu
     else:
       ret.gearShifter = self.CS.gear_shifter
-    
+
     ret.gasbuttonstatus = self.CS.cstm_btns.get_button_status("gas")
     ret.readdistancelines = self.CS.read_distance_lines
     # gas pedal

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -57,7 +57,7 @@ class CarInterface(object):
     ret.enableCamera = True
 
     std_cargo = 136
-    ret.steerRateCost = 0.7
+    ret.steerRateCost = 0.15
 
     if candidate in [CAR.IMPREZA, CAR.XV]:
       ret.mass = 1568 + std_cargo
@@ -65,7 +65,7 @@ class CarInterface(object):
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 15
       tire_stiffness_factor = 1.0
-      ret.steerActuatorDelay = 0.4   # end-to-end angle controller
+      ret.steerActuatorDelay = 0.1   # end-to-end angle controller
       ret.lateralTuning.pid.kf = 0.00005
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
@@ -78,7 +78,7 @@ class CarInterface(object):
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 20            # learned, 14 stock
       tire_stiffness_factor = 0.78
-      ret.steerActuatorDelay = 0.4
+      ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kf = 0.00003
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.,10.], [0.,10.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.07,0.15], [0.02,0.02]]
@@ -91,7 +91,7 @@ class CarInterface(object):
       ret.centerToFront = ret.wheelbase * 0.5
       ret.steerRatio = 14.5
       tire_stiffness_factor = 1.0
-      ret.steerActuatorDelay = 0.4
+      ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kf = 0.00005
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.1, 0.2], [0.01, 0.02]]
@@ -185,7 +185,7 @@ class CarInterface(object):
     ret.rightBlinker = self.CS.right_blinker_on
     ret.seatbeltUnlatched = self.CS.seatbelt_unlatched
     ret.doorOpen = self.CS.door_open
-    
+
     ret.gasbuttonstatus = self.CS.gasMode
     ret.readdistancelines = 1
     ret.genericToggle = False
@@ -194,7 +194,7 @@ class CarInterface(object):
     ret.accSlowToggle = False
     ret.blindspot = False
     ret.brakeLights = False
-    
+
     buttonEvents = []
 
     # blinkers
@@ -224,7 +224,7 @@ class CarInterface(object):
 
     if self.CS.steer_not_allowed:
       events.append(create_event('steerUnavailable', [ET.NO_ENTRY, ET.IMMEDIATE_DISABLE, ET.PERMANENT]))
-      
+
     if ret.seatbeltUnlatched and (self.CS.acc_active and not self.acc_active_prev):
       events.append(create_event('seatbeltNotLatched', [ET.NO_ENTRY, ET.SOFT_DISABLE]))
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -10,7 +10,7 @@ from selfdrive.swaglog import cloudlog
 import selfdrive.kegman_conf as kegman
 
 steeringAngleoffset = float(kegman.conf['angle_steers_offset'])  # deg offset
-   
+
 try:
   from selfdrive.car.toyota.carcontroller import CarController
 except ImportError:
@@ -97,7 +97,7 @@ class CarInterface(object):
       ret.longitudinalTuning.kpV = [2.0, 1.0, 0.5]  # braking tune from rav4h
       ret.longitudinalTuning.kiV = [0.30, 0.20]
 
-    ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
+    ret.steerActuatorDelay = 0.1  # Default delay, Prius has larger delay
     if candidate != CAR.PRIUS:
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
@@ -110,7 +110,7 @@ class CarInterface(object):
       ret.steerRatio = 15.00   # unknown end-to-end spec
       tire_stiffness_factor = 0.6371   # hand-tune
       ret.mass = 3045 * CV.LB_TO_KG + std_cargo
-      
+
       ret.lateralTuning.init('indi')
       ret.lateralTuning.indi.innerLoopGain = 4.0
       ret.lateralTuning.indi.outerLoopGain = 3.0
@@ -126,10 +126,11 @@ class CarInterface(object):
       ret.wheelbase = 2.66 # 2.65 default
       ret.steerRatio = 17.28 # Rav4 0.5.10 tuning value
       ret.mass = 4100./2.205 + std_cargo  # mean between normal and hybrid
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.03]] #0.6 0.05 default
+      #ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.03]] #0.6 0.05 default
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.4], [0.05]] #0.6 0.05 default
       ret.wheelbase = 2.65
       tire_stiffness_factor = 0.5533
-      ret.lateralTuning.pid.kf = 0.00001 # full torque for 10 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00007 # full torque for 10 deg at 80mph means 0.00007818594
 
     elif candidate in [CAR.RAV4H]:
       stop_and_go = True
@@ -137,10 +138,10 @@ class CarInterface(object):
       ret.wheelbase = 2.65 # 2.65 default
       ret.steerRatio = 16.53 # 0.5.10 tuning
       ret.mass = 4100./2.205 + std_cargo  # mean between normal and hybrid
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.03]] #0.6 0.05 default
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.4], [0.05]] #0.6 0.05 default
       ret.wheelbase = 2.65
       tire_stiffness_factor = 0.5533
-      ret.lateralTuning.pid.kf = 0.0001 # full torque for 10 deg at 80mph means 0.00007818594
+      ret.lateralTuning.pid.kf = 0.00007 # full torque for 10 deg at 80mph means 0.00007818594
 
     elif candidate == CAR.RAV4_2019:
       stop_and_go = True
@@ -149,8 +150,8 @@ class CarInterface(object):
       ret.steerRatio = 17.0
       tire_stiffness_factor = 0.7933
       ret.mass = 3370. * CV.LB_TO_KG + std_cargo
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.05]]
-      ret.lateralTuning.pid.kf = 0.0001
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.4], [0.05]]
+      ret.lateralTuning.pid.kf = 0.00007
 
     elif candidate == CAR.COROLLA_HATCH:
       stop_and_go = True
@@ -181,7 +182,7 @@ class CarInterface(object):
       ret.mass = 4481 * CV.LB_TO_KG + std_cargo  # mean between min and max
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.02]]
       ret.lateralTuning.pid.kf = 0.00007   # full torque for 10 deg at 80mph means 0.00007818594
-      
+
     elif candidate == CAR.LEXUS_IS:
       stop_and_go = False
       ret.safetyParam = 100
@@ -263,10 +264,10 @@ class CarInterface(object):
     if candidate == CAR.OLD_CAR:
       ret.centerToFront = ret.wheelbase * 0.5
     else:
-      ret.centerToFront = ret.wheelbase * 0.44  
+      ret.centerToFront = ret.wheelbase * 0.44
 
 
-    ret.steerRateCost = 1.
+    ret.steerRateCost = 0.1
 
 
     #detect the Pedal address
@@ -339,7 +340,7 @@ class CarInterface(object):
     canMonoTimes = []
 
     self.cp.update(int(sec_since_boot() * 1e9), False)
-    
+
     self.cp_cam.update(int(sec_since_boot() * 1e9), False)
 
     self.CS.update(self.cp, self.cp_cam)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -20,10 +20,10 @@ class LatControlPID(object):
     self.rate_ff_gain = 0.01
     self.angle_ff_bp = [[0.5, 5.0],[0.0, 1.0]]
     self.sat_time = 0.0
-    
+
   def reset(self):
     self.pid.reset()
-    
+
   def adjust_angle_gain(self):
     if (self.pid.f > 0) == (self.pid.i > 0) and abs(self.pid.i) >= abs(self.previous_integral):
       self.angle_ff_gain *= 1.0001
@@ -43,8 +43,8 @@ class LatControlPID(object):
       self.pid.reset()
       self.previous_integral = 0.0
     else:
-      self.angle_steers_des = interp(sec_since_boot(), path_plan.mpcTimes, path_plan.mpcAngles)
-      
+      self.angle_steers_des = path_plan.angleSteers  #  interp(sec_since_boot(), path_plan.mpcTimes, path_plan.mpcAngles)
+
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max
       self.pid.neg_limit = -steers_max
@@ -55,13 +55,13 @@ class LatControlPID(object):
         angle_feedforward *= self.angle_ff_ratio * self.angle_ff_gain
         rate_feedforward = (1.0 - self.angle_ff_ratio) * self.rate_ff_gain * path_plan.rateSteers
         steer_feedforward = v_ego**2 * (rate_feedforward + angle_feedforward)
-        
+
         if v_ego > 10.0:
           if abs(angle_steers) > (self.angle_ff_bp[0][1] / 2.0):
             self.adjust_angle_gain()
           else:
             self.previous_integral = self.pid.i
-        
+
       deadzone = 0.0
       output_steer = self.pid.update(self.angle_steers_des, angle_steers, check_saturation=(v_ego > 10), override=steer_override,
                                      feedforward=steer_feedforward, speed=v_ego, deadzone=deadzone)

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -44,7 +44,7 @@ class LatControlPID(object):
       self.previous_integral = 0.0
     else:
       self.angle_steers_des = path_plan.angleSteers  #  interp(sec_since_boot(), path_plan.mpcTimes, path_plan.mpcAngles)
-
+      angle_steers_des_alca = interp(sec_since_boot(), path_plan.mpcTimes, path_plan.mpcAngles)
       steers_max = get_steer_max(CP, v_ego)
       self.pid.pos_limit = steers_max
       self.pid.neg_limit = -steers_max
@@ -92,4 +92,4 @@ class LatControlPID(object):
     if CP.steerControlType == car.CarParams.SteerControlType.torque:
       return output_steer, path_plan.angleSteers, pid_log
     else:
-      return self.angle_steers_des, path_plan.angleSteers
+      return angle_steers_des_alca, path_plan.angleSteers


### PR DESCRIPTION
This is from this PR in comma's openpilot repo.
https://github.com/commaai/openpilot/pull/700

Note that the changes to steerActuatorDelay seem necessary, since the other values were just bandaids for the bug.  Also, the reduction in steerRateCost are necessary to restore steering response.  I've tested the values for Honda and Toyota, but not the others.  They are just educated guesses.
