### PR TITLE
opParams and opEdit refactor

### DIFF
--- a/common/colors.py
+++ b/common/colors.py
@@ -1,0 +1,43 @@
+class COLORS:
+  def __init__(self):
+    self.HEADER = '\033[95m'
+    self.OKBLUE = '\033[94m'
+    self.CBLUE = '\33[44m'
+    self.BOLD = '\033[1m'
+    self.CITALIC = '\33[3m'
+    self.OKGREEN = '\033[92m'
+    self.CWHITE = '\33[37m'
+    self.ENDC = '\033[0m' + self.CWHITE
+    self.UNDERLINE = '\033[4m'
+    self.PINK = '\33[38;5;207m'
+    self.PRETTY_YELLOW = self.BASE(220)
+
+    self.RED = '\033[91m'
+    self.PURPLE_BG = '\33[45m'
+    self.YELLOW = '\033[93m'
+    self.BLUE_GREEN = self.BASE(85)
+
+    self.FAIL = self.RED
+    self.INFO = self.PURPLE_BG
+    self.SUCCESS = self.OKGREEN
+    self.PROMPT = self.YELLOW
+    self.DBLUE = '\033[36m'
+    self.CYAN = self.BASE(39)
+    self.WARNING = '\033[33m'
+
+  def BASE(self, col):  # seems to support more colors
+    return '\33[38;5;{}m'.format(col)
+
+  def BASEBG(self, col):  # seems to support more colors
+    return '\33[48;5;{}m'.format(col)
+
+
+COLORS = COLORS()
+
+
+def opParams_warning(msg):
+  print('{}opParams WARNING: {}{}'.format(COLORS.WARNING, msg, COLORS.ENDC))
+
+
+def opParams_error(msg):
+  print('{}opParams ERROR: {}{}'.format(COLORS.FAIL, msg, COLORS.ENDC))

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -94,6 +94,7 @@ class opParams:
                                                                  'The range is limited from 0.85 to 1.3. Set to None to disable', live=True),
                         'use_virtual_middle_line': Param(False, bool, 'For roads over 4m wide, hug right. For roads under 2m wide, hug left.'),
                         'uniqueID': Param(None, [type(None), str], 'User\'s unique ID'),
+                        'autoUpdate': Param(True, bool, 'Whether to auto-update'),
                         'ludicrous_mode': Param(False, bool, 'Double overall acceleration!')}
 
     self._params_file = '/data/op_params.json'

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -93,6 +93,7 @@ class opParams:
                         'min_TR': Param(None, VT.none_or_number, 'The minimum allowed following distance in seconds. Default is 0.9 seconds.\n'
                                                                  'The range is limited from 0.85 to 1.3. Set to None to disable', live=True),
                         'use_virtual_middle_line': Param(False, bool, 'For roads over 4m wide, hug right. For roads under 2m wide, hug left.'),
+                        'uniqueID': Param(None, [type(None), str], 'User\'s unique ID'),
                         'ludicrous_mode': Param(False, bool, 'Double overall acceleration!')}
 
     self._params_file = '/data/op_params.json'

--- a/common/op_params.py
+++ b/common/op_params.py
@@ -2,223 +2,208 @@
 import os
 import json
 from common.travis_checker import travis
+from common.colors import opParams_error as error
+from common.colors import opParams_warning as warning
 try:
   from common.realtime import sec_since_boot
 except ImportError:
   import time
   sec_since_boot = time.time
-  print("opParams WARNING: using python time.time() instead of faster sec_since_boot")
+  warning("Using python time.time() instead of faster sec_since_boot")
 
 
-class KeyInfo:
-  default = None
-  allowed_types = []
-  is_list = False
-  has_allowed_types = False
-  live = False
-  has_default = False
-  has_description = False
-  hidden = False
+class ValueTypes:
+  number = [float, int]
+  none_or_number = [type(None), float, int]
+
+
+class Param:
+  def __init__(self, default=None, allowed_types=[], description=None, live=False, hidden=False):
+    self.default = default
+    if not isinstance(allowed_types, list):
+      allowed_types = [allowed_types]
+    self.allowed_types = allowed_types
+    self.description = description
+    self.hidden = hidden
+    self.live = live
+    self._create_attrs()
+
+  def is_valid(self, value):
+    if not self.has_allowed_types:
+      return True
+    return type(value) in self.allowed_types
+
+  def _create_attrs(self):  # Create attributes and check Param is valid
+    self.has_allowed_types = isinstance(self.allowed_types, list) and len(self.allowed_types) > 0
+    self.has_description = self.description is not None
+    self.is_list = list in self.allowed_types
+    if self.has_allowed_types:
+      assert type(self.default) in self.allowed_types, 'Default value type must be in specified allowed_types!'
+    if self.is_list:
+      self.allowed_types.remove(list)
 
 
 class opParams:
   def __init__(self):
     """
-      To add your own parameter to opParams in your fork, simply add a new dictionary entry with the name of your parameter and its default value to save to new users' op_params.json file.
-      The description, allowed_types, and live keys are no longer required but recommended to help users edit their parameters with opEdit correctly.
+      To add your own parameter to opParams in your fork, simply add a new entry in self.fork_params, instancing a new Param class with at minimum a default value.
+      The allowed_types and description args are not required but highly recommended to help users edit their parameters with opEdit safely.
         - The description value will be shown to users when they use opEdit to change the value of the parameter.
-        - The allowed_types key is used to restrict what kinds of values can be entered with opEdit so that users can't reasonably break the fork with unintended behavior.
+        - The allowed_types arg is used to restrict what kinds of values can be entered with opEdit so that users can't crash openpilot with unintended behavior.
+              (setting a param intended to be a number with a boolean, or viceversa for example)
           Limiting the range of floats or integers is still recommended when `.get`ting the parameter.
-          When a None value is allowed, use `type(None)` instead of None, as opEdit checks the type against the values in the key with `isinstance()`.
-        - Finally, the live key tells both opParams and opEdit that it's a live parameter that will change. Therefore, you must place the `op_params.get()` call in the update function so that it can update.
-      Here's an example of the minimum required dictionary:
+          When a None value is allowed, use `type(None)` instead of None, as opEdit checks the type against the values in the arg with `isinstance()`.
+        - Finally, the live arg tells both opParams and opEdit that it's a live parameter that will change. Therefore, you must place the `op_params.get()` call in the update function so that it can update.
 
-      self.default_params = {'camera_offset': {'default': 0.06}}
+      Here's an example of a good fork_param entry:
+      self.fork_params = {'camera_offset': Param(default=0.06, allowed_types=VT.number)}  # VT.number allows both floats and ints
     """
 
-    self.default_params = {'awareness_factor': {'default': 10., 'allowed_types': [float, int], 'description': 'Multiplier for the awareness times', 'live': False},
-                           'alca_min_speed': {'default': 20, 'allowed_types': [float, int], 'description': 'Speed limit to start ALC in MPH', 'live': False},
-                           'alca_nudge_required': {'default': False, 'allowed_types': [bool], 'description': "Require nudge to start ALC", 'live': False},
-                           'camera_offset': {'default': 0.06, 'allowed_types': [float, int], 'description': 'Your camera offset to use in lane_planner.py', 'live': True},
-                           'curvature_factor': {'default': 1.2, 'allowed_types': [float, int], 'description': 'Multiplier for the curvature slowdown. Increase for less braking.', 'live': False},
-                           'cloak': {'default': True, 'allowed_types': [bool], 'description': "make comma believe you are on their fork", 'live': False},
-                           'default_brake_distance': {'default': 250.0, 'allowed_types': [float, int], 'description': 'Distance in m to start braking for mapped speeds.', 'live': False},
-                           'dynamic_follow': {'default': 'normal', 'allowed_types': [str],
-                                              'description': "Can be: ('close', 'normal', 'far'): Left to right increases in following distance.\n"
-                                                             "All profiles support dynamic follow so you'll get your preferred distance while\n"
-                                                             "retaining the smoothness and safety of dynamic follow!", 'live': True},
-                           'force_pedal': {'default': False, 'allowed_types': [bool], 'description': "If openpilot isn't recognizing your comma pedal, set this to True", 'live': False},
-                           'global_df_mod': {'default': None, 'allowed_types': [type(None), float, int], 'description': 'The multiplier for the current distance used by dynamic follow. The range is limited from 0.85 to 1.2\n'
-                                                                                                                        'Smaller values will get you closer, larger will get you farther\n'
-                                                                                                                        'This is multiplied by any profile that\'s active. Set to None to disable', 'live': True},
-                           'hide_auto_df_alerts': {'default': True, 'allowed_types': [bool], 'description': 'Hides the alert that shows what profile the model has chosen'},
-                           'keep_openpilot_engaged': {'default': True, 'allowed_types': [bool],
-                                                      'description': 'True is stock behavior in this fork. False lets you use the brake and cruise control stalk to disengage as usual', 'live': False},
-                           'limit_rsa': {'default': False, 'allowed_types': [bool], 'description': "Switch off RSA above rsa_max_speed", 'live': False},
-                           'mpc_offset': {'default': 0.0, 'allowed_types': [float, int], 'description': 'Offset model braking by how many m/s. Lower numbers equals more model braking', 'live': True},
-                           'offset_limit': {'default': 0, 'allowed_types': [float, int], 'description': 'Speed at which apk percent offset will work in m/s', 'live': False},
-                           'osm': {'default': True, 'allowed_types': [bool], 'description': 'Whether to use OSM for drives', 'live': False},
-                           'op_edit_live_mode': {'default': False, 'allowed_types': [bool], 'description': 'This parameter controls which mode opEdit starts in. It should be hidden from the user with the hide key', 'hide': True},
-                           'rolling_stop': {'default': False, 'allowed_types': [bool], 'description': 'If you do not want stop signs to go down to 0 kph enable this for 9kph slow down', 'live': False},
-                           'rsa_max_speed': {'default': 24.5, 'allowed_types': [float, int], 'description': 'Speed limit to ignore RSA in m/s', 'live': False},
-                           'smart_speed': {'default': True, 'allowed_types': [bool], 'description': 'Whether to use Smart Speed for drives above smart_speed_max_vego', 'live': False},
-                           'smart_speed_max_vego': {'default': 26.8, 'allowed_types': [float, int], 'description': 'Speed limit to ignore Smartspeed in m/s', 'live': False},
-                           'spairrowtuning': {'default': False, 'allowed_types': [bool], 'description': 'Better Tuning for Corolla', 'live': False},
-                           'speed_offset': {'default': 0, 'allowed_types': [float, int], 'description': 'Speed limit offset in m/s', 'live': True},
-                           'traffic_light_alerts': {'default': False, 'allowed_types': [bool], 'description': "Switch off the traffic light alerts", 'live': False},
-                           'traffic_lights': {'default': False, 'allowed_types': [bool], 'description': "Should Openpilot stop for traffic lights", 'live': False},
-                           'traffic_lights_without_direction': {'default': False, 'allowed_types': [bool], 'description': "Should Openpilot stop for traffic lights without a direction specified", 'live': False},
-                           'use_car_caching': {'default': True, 'allowed_types': [bool], 'description': 'Whether to use fingerprint caching', 'live': False},
-                           'min_TR': {'default': None, 'allowed_types': [type(None), float, int], 'description': 'The minimum allowed following distance in seconds. Default is 0.9 seconds.\n'
-                                                                                                                 'The range is limited from 0.85 to 1.3. Set to None to disable', 'live': True},
-                           'use_virtual_middle_line': {'default': False, 'allowed_types': [bool], 'description': 'For roads over 4m wide, hug right. For roads under 2m wide, hug left.', 'live': False},
-                           'ludicrous_mode': {'default': False, 'allowed_types': [bool], 'description': 'Double overall acceleration!', 'live': False},
-                           }
+    VT = ValueTypes()
+    self.fork_params = {'awareness_factor': Param(10., VT.number, 'Multiplier for the awareness times'),
+                        'alca_min_speed': Param(20, VT.number, 'Speed limit to start ALC in MPH'),
+                        'alca_nudge_required': Param(False, bool, "Require nudge to start ALC"),
+                        'camera_offset': Param(0.06, VT.number, 'Your camera offset to use in lane_planner.py', live=True),
+                        'curvature_factor': Param(1.2, VT.number, 'Multiplier for the curvature slowdown. Increase for less braking.'),
+                        'cloak': Param(True, bool, "make comma believe you are on their fork"),
+                        'default_brake_distance': Param(250.0, VT.number, 'Distance in m to start braking for mapped speeds.'),
+                        'dynamic_follow': Param('normal', str, "Can be: ('close', 'normal', 'far'): Left to right increases in following distance.\n"
+                                                               "All profiles support dynamic follow so you'll get your preferred distance while\n"
+                                                               "retaining the smoothness and safety of dynamic follow!", live=True),
+                        'force_pedal': Param(False, bool, "If openpilot isn't recognizing your comma pedal, set this to True"),
+                        'global_df_mod': Param(None, VT.none_or_number, 'The multiplier for the current distance used by dynamic follow. The range is limited from 0.85 to 1.2\n'
+                                                                        'Smaller values will get you closer, larger will get you farther\n'
+                                                                        'This is multiplied by any profile that\'s active. Set to None to disable', live=True),
+                        'hide_auto_df_alerts': Param(True, bool, 'Hides the alert that shows what profile the model has chosen'),
+                        'keep_openpilot_engaged': Param(True, bool, 'True is stock behavior in this fork. False lets you use the brake and cruise control stalk to disengage as usual'),
+                        'limit_rsa': Param(False, bool, "Switch off RSA above rsa_max_speed"),
+                        'mpc_offset': Param(0.0, VT.number, 'Offset model braking by how many m/s. Lower numbers equals more model braking', live=True),
+                        'offset_limit': Param(0, VT.number, 'Speed at which apk percent offset will work in m/s'),
+                        'osm': Param(True, bool, 'Whether to use OSM for drives'),
+                        'rolling_stop': Param(False, bool, 'If you do not want stop signs to go down to 0 kph enable this for 9kph slow down'),
+                        'rsa_max_speed': Param(24.5, VT.number, 'Speed limit to ignore RSA in m/s'),
+                        'smart_speed': Param(True, bool, 'Whether to use Smart Speed for drives above smart_speed_max_vego'),
+                        'smart_speed_max_vego': Param(26.8, VT.number, 'Speed limit to ignore Smartspeed in m/s'),
+                        'spairrowtuning': Param(False, bool, 'Better Tuning for Corolla'),
+                        'speed_offset': Param(0, VT.number, 'Speed limit offset in m/s', live=True),
+                        'traffic_light_alerts': Param(False, bool, "Switch off the traffic light alerts"),
+                        'traffic_lights': Param(False, bool, "Should Openpilot stop for traffic lights"),
+                        'traffic_lights_without_direction': Param(False, bool, "Should Openpilot stop for traffic lights without a direction specified"),
+                        'use_car_caching': Param(True, bool, 'Whether to use fingerprint caching'),
+                        'min_TR': Param(None, VT.none_or_number, 'The minimum allowed following distance in seconds. Default is 0.9 seconds.\n'
+                                                                 'The range is limited from 0.85 to 1.3. Set to None to disable', live=True),
+                        'use_virtual_middle_line': Param(False, bool, 'For roads over 4m wide, hug right. For roads under 2m wide, hug left.'),
+                        'ludicrous_mode': Param(False, bool, 'Double overall acceleration!')}
 
-    self.params = {}
-    self.params_file = "/data/op_params.json"
-    self.last_read_time = sec_since_boot()
+    self._params_file = '/data/op_params.json'
+    self._backup_file = '/data/op_params_corrupt.json'
+    self._last_read_time = sec_since_boot()
     self.read_frequency = 2.5  # max frequency to read with self.get(...) (sec)
-    self.force_update = False  # replaces values with default params if True, not just add add missing key/value pairs
-    self.to_delete = ['reset_integral', 'log_data']  # a list of params you want to delete (unused)
-    self.run_init()  # restores, reads, and updates params
+    self._to_delete = ['reset_integral', 'log_data']  # a list of params you want to delete (unused)
+    self._run_init()  # restores, reads, and updates params
 
-  def run_init(self):  # does first time initializing of default params
+  def _run_init(self):  # does first time initializing of default params
+    # Two required parameters for opEdit
+    self.fork_params['username'] = Param(None, [type(None), str, bool], 'Your identifier provided with any crash logs sent to Sentry.\nHelps the developer reach out to you if anything goes wrong')
+    self.fork_params['op_edit_live_mode'] = Param(False, bool, 'This parameter controls which mode opEdit starts in', hidden=True)
+    self.params = self._get_all_params(default=True)  # in case file is corrupted
     if travis:
-      self.params = self._format_default_params()
       return
 
-    self.params = self._format_default_params()  # in case any file is corrupted
-
-    to_write = False
-    if os.path.isfile(self.params_file):
+    if os.path.isfile(self._params_file):
       if self._read():
-        to_write = not self._add_default_params()  # if new default data has been added
-        to_write = self._delete_old or to_write  # or if old params have been deleted
-      else:  # don't overwrite corrupted params, just print
-        print("opParams ERROR: Can't read op_params.json file")
+        to_write = self._add_default_params()  # if new default data has been added
+        to_write |= self._delete_old()  # or if old params have been deleted
+      else:  # backup and re-create params file
+        error("Can't read op_params.json file, backing up to /data/op_params_corrupt.json and re-creating file!")
+        to_write = True
+        if os.path.isfile(self._backup_file):
+          os.remove(self._backup_file)
+        os.rename(self._params_file, self._backup_file)
     else:
       to_write = True  # user's first time running a fork with op_params, write default params
 
     if to_write:
       self._write()
-      os.chmod(self.params_file, 0o764)
+      os.chmod(self._params_file, 0o764)
 
-  def get(self, key=None, default=None, force_update=False):  # can specify a default value if key doesn't exist
+  def get(self, key=None, force_live=False):  # any params you try to get MUST be in fork_params
+    param_info = self.param_info(key)
+    self._update_params(param_info, force_live)
+
     if key is None:
-      return self._get_all()
+      return self._get_all_params()
 
-    key_info = self.key_info(key)
-    self._update_params(key_info, force_update)
-    if key in self.params:
-      if key_info.has_allowed_types:
-        value = self.params[key]
-        if type(value) in key_info.allowed_types:
-          return value  # all good, returning user's value
+    self._check_key_exists(key, 'get')
+    value = self.params[key]
+    if param_info.is_valid(value):  # always valid if no allowed types, otherwise checks to make sure
+      return value  # all good, returning user's value
 
-        print('opParams WARNING: User\'s value is not valid!')
-        if key_info.has_default:  # invalid value type, try to use default value
-          if type(key_info.default) in key_info.allowed_types:  # actually check if the default is valid
-            # return default value because user's value of key is not in the allowed_types to avoid crashing openpilot
-            return key_info.default
-
-        return self._value_from_types(key_info.allowed_types)  # else use a standard value based on type (last resort to keep openpilot running if user's value is of invalid type)
-      else:
-        return self.params[key]  # no defined allowed types, returning user's value
-
-    return default  # not in params
+    warning('User\'s value type is not valid! Returning default')  # somehow... it should always be valid
+    return param_info.default  # return default value because user's value of key is not in allowed_types to avoid crashing openpilot
 
   def put(self, key, value):
+    self._check_key_exists(key, 'put')
+    if not self.param_info(key).is_valid(value):
+      raise Exception('opParams: Tried to put a value of invalid type!')
     self.params.update({key: value})
     self._write()
 
-  def delete(self, key):
+  def delete(self, key):  # todo: might be obsolete. remove?
     if key in self.params:
       del self.params[key]
       self._write()
 
-  def key_info(self, key):
-    key_info = KeyInfo()
-    if key is None or key not in self.default_params:
-      return key_info
-    if key in self.default_params:
-      if 'allowed_types' in self.default_params[key]:
-        allowed_types = self.default_params[key]['allowed_types']
-        if isinstance(allowed_types, list) and len(allowed_types) > 0:
-          key_info.has_allowed_types = True
-          key_info.allowed_types = list(allowed_types)
-          if list in [type(typ) for typ in allowed_types]:
-            key_info.is_list = True
-            key_info.allowed_types.remove(list)
-            key_info.allowed_types = key_info.allowed_types[0]
+  def param_info(self, key):
+    if key in self.fork_params:
+      return self.fork_params[key]
+    return Param()
 
-      if 'live' in self.default_params[key]:
-        key_info.live = self.default_params[key]['live']
-
-      if 'default' in self.default_params[key]:
-        key_info.has_default = True
-        key_info.default = self.default_params[key]['default']
-
-      key_info.has_description = 'description' in self.default_params[key]
-
-      if 'hide' in self.default_params[key]:
-        key_info.hidden = self.default_params[key]['hide']
-
-    return key_info
+  def _check_key_exists(self, key, met):
+    if key not in self.fork_params or key not in self.params:
+      raise Exception('opParams: Tried to {} an unknown parameter! Key not in fork_params: {}'.format(met, key))
 
   def _add_default_params(self):
-    prev_params = dict(self.params)
-    for key in self.default_params:
-      if self.force_update:
-        self.params[key] = self.default_params[key]['default']
-      elif key not in self.params:
-        self.params[key] = self.default_params[key]['default']
-    return prev_params == self.params
+    added = False
+    for key, param in self.fork_params.items():
+      if key not in self.params:
+        self.params[key] = param.default
+        added = True
+      elif not param.is_valid(self.params[key]):
+        warning('Value type of user\'s {} param not in allowed types, replacing with default!'.format(key))
+        self.params[key] = param.default
+        added = True
+    return added
 
-  def _format_default_params(self):
-    return {key: self.default_params[key]['default'] for key in self.default_params}
-
-  @property
   def _delete_old(self):
     deleted = False
-    for param in self.to_delete:
+    for param in self._to_delete:
       if param in self.params:
         del self.params[param]
         deleted = True
     return deleted
 
-  def _get_all(self):  # returns all non-hidden params
-    return {k: v for k, v in self.params.items() if not self.key_info(k).hidden}
+  def _get_all_params(self, default=False, return_hidden=False):
+    if default:
+      return {k: p.default for k, p in self.fork_params.items()}
+    return {k: self.params[k] for k, p in self.fork_params.items() if k in self.params and (not p.hidden or return_hidden)}
 
-  def _value_from_types(self, allowed_types):
-    if list in allowed_types:
-      return []
-    elif float in allowed_types or int in allowed_types:
-      return 0
-    elif type(None) in allowed_types:
-      return None
-    elif str in allowed_types:
-      return ''
-    return None  # unknown type
-
-  def _update_params(self, key_info, force_update):
-    if force_update or key_info.live:  # if is a live param, we want to get updates while openpilot is running
-      if not travis and (sec_since_boot() - self.last_read_time >= self.read_frequency or force_update):  # make sure we aren't reading file too often
+  def _update_params(self, param_info, force_live):
+    if force_live or param_info.live:  # if is a live param, we want to get updates while openpilot is running
+      if not travis and sec_since_boot() - self._last_read_time >= self.read_frequency:  # make sure we aren't reading file too often
         if self._read():
-          self.last_read_time = sec_since_boot()
+          self._last_read_time = sec_since_boot()
 
   def _read(self):
     try:
-      with open(self.params_file, "r") as f:
-        params = f.read()
-      self.params = json.loads(params)
+      with open(self._params_file, "r") as f:
+        self.params = json.loads(f.read())
       return True
     except Exception as e:
-      print('opParams ERROR: {}'.format(e))
-      self.params = self._format_default_params()
+      error(e)
       return False
 
   def _write(self):
     if not travis:
-      with open(self.params_file, "w") as f:
+      with open(self._params_file, "w") as f:
         f.write(json.dumps(self.params, indent=2))  # can further speed it up by remove indentation but makes file hard to read

--- a/op_edit.py
+++ b/op_edit.py
@@ -1,31 +1,9 @@
 #!/usr/bin/env python3
-import os
-os.chdir('/data/openpilot/')
 import time
 from common.op_params import opParams
 import ast
 import difflib
-
-
-class STYLES:
-  # HEADER = '\033[95m'
-  # OKBLUE = '\033[94m'
-  # CBLUE = '\33[44m'
-  # BOLD = '\033[1m'
-  OKGREEN = '\033[92m'
-  CWHITE = '\33[37m'
-  ENDC = '\033[0m' + CWHITE
-  UNDERLINE = '\033[4m'
-
-  RED = '\033[91m'
-  PURPLE_BG = '\33[45m'
-  YELLOW = '\033[93m'
-
-  FAIL = RED
-  INFO = PURPLE_BG
-  SUCCESS = OKGREEN
-  PROMPT = YELLOW
-  CYAN = '\033[36m'
+from common.colors import COLORS
 
 
 class opEdit:  # use by running `python /data/openpilot/op_edit.py`
@@ -33,8 +11,12 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
     self.op_params = opParams()
     self.params = None
     self.sleep_time = 0.75
-    self.live_tuning = self.op_params.get('op_edit_live_mode', False)
-    self.username = self.op_params.get('username', None)
+    self.live_tuning = self.op_params.get('op_edit_live_mode')
+    self.username = self.op_params.get('username')
+    self.type_colors = {int: COLORS.BASE(179), float: COLORS.BASE(179),
+                        bool: {False: COLORS.RED, True: COLORS.OKGREEN},
+                        type(None): COLORS.BASE(177),
+                        str: COLORS.BASE(77)}
 
     self.last_choice = None
 
@@ -69,29 +51,44 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       if not self.live_tuning:
         self.info('Here are your parameters:', end='\n', sleep_time=0)
       else:
-        self.info('Here are your live parameters:', end='\n', sleep_time=0)
-      self.params = self.op_params.get(force_update=True)
+        self.info('Here are your live parameters:', sleep_time=0)
+        self.info('(changes take effect within {} seconds)'.format(self.op_params.read_frequency), end='\n', sleep_time=0)
+      self.params = self.op_params.get(force_live=True)
       if self.live_tuning:  # only display live tunable params
-        self.params = {k: v for k, v in self.params.items() if self.op_params.key_info(k).live}
+        self.params = {k: v for k, v in self.params.items() if self.op_params.param_info(k).live}
 
-      values_list = [self.params[i] if len(str(self.params[i])) < 20 else '{} ... {}'.format(str(self.params[i])[:30], str(self.params[i])[-15:]) for i in self.params]
-      live = ['(live!)' if self.op_params.key_info(i).live else '' for i in self.params]
+      values_list = []
+      for k, v in self.params.items():
+        if len(str(v)) < 20:
+          v_color = ''
+          if type(v) in self.type_colors:
+            v_color = self.type_colors[type(v)]
+            if isinstance(v, bool):
+              v_color = v_color[v]
+          v = '{}{}{}'.format(v_color, v, COLORS.ENDC)
+        else:
+          v = '{} ... {}'.format(str(v)[:30], str(v)[-15:])
+        values_list.append(v)
+
+      live = [COLORS.INFO + '(live!)' + COLORS.ENDC if self.op_params.param_info(k).live else '' for k in self.params]
 
       to_print = []
+      blue_gradient = [33, 39, 45, 51, 87]
       for idx, param in enumerate(self.params):
         line = '{}. {}: {}  {}'.format(idx + 1, param, values_list[idx], live[idx])
         if idx == self.last_choice and self.last_choice is not None:
-          line = STYLES.OKGREEN + line
+          line = COLORS.OKGREEN + line
         else:
-          line = STYLES.CYAN + line
+          _color = blue_gradient[min(round(idx / len(self.params) * len(blue_gradient)), len(blue_gradient) - 1)]
+          line = COLORS.BASE(_color) + line
         to_print.append(line)
 
-      extras = {'a': 'Add new parameter',
-                'd': 'Delete parameter',
-                'l': 'Toggle live tuning',
-                'e': 'Exit opEdit'}
+      extras = {'a': ('Add new parameter', COLORS.OKGREEN),
+                'd': ('Delete parameter', COLORS.FAIL),
+                'l': ('Toggle live tuning', COLORS.WARNING),
+                'e': ('Exit opEdit', COLORS.PINK)}
 
-      to_print += ['---'] + ['{}. {}'.format(e, extras[e]) for e in extras]
+      to_print += ['---'] + ['{}. {}'.format(ext_col + e, ext_txt + COLORS.ENDC) for e, (ext_txt, ext_col) in extras.items()]
       print('\n'.join(to_print))
       self.prompt('\nChoose a parameter to edit (by index or name):')
 
@@ -147,41 +144,47 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def change_parameter(self, choice):
     while True:
       chosen_key = list(self.params)[choice]
-      key_info = self.op_params.key_info(chosen_key)
+      param_info = self.op_params.param_info(chosen_key)
 
       old_value = self.params[chosen_key]
       self.info('Chosen parameter: {}'.format(chosen_key), sleep_time=0)
 
       to_print = []
-      if key_info.has_description:
-        to_print.append(STYLES.OKGREEN + '>>  Description: {}'.format(self.op_params.default_params[chosen_key]['description'].replace('\n', '\n  > ')) + STYLES.ENDC)
-      if key_info.has_allowed_types:
-        to_print.append(STYLES.RED + '>>  Allowed types: {}'.format(', '.join([i.__name__ for i in key_info.allowed_types])) + STYLES.ENDC)
-      if key_info.live:
-        to_print.append(STYLES.YELLOW + '>>  This parameter supports live tuning! Updates should take affect within 5 seconds' + STYLES.ENDC)
+      if param_info.has_description:
+        to_print.append(COLORS.OKGREEN + '>>  Description: {}'.format(param_info.description.replace('\n', '\n  > ')) + COLORS.ENDC)
+      if param_info.has_allowed_types:
+        to_print.append(COLORS.RED + '>>  Allowed types: {}'.format(', '.join([at.__name__ for at in param_info.allowed_types])) + COLORS.ENDC)
+      if param_info.live:
+        live_msg = '>>  This parameter supports live tuning!'
+        if not self.live_tuning:
+          live_msg += ' Updates should take effect within {} seconds'.format(self.op_params.read_frequency)
+        to_print.append(COLORS.YELLOW + live_msg + COLORS.ENDC)
 
       if to_print:
         print('\n{}\n'.format('\n'.join(to_print)))
 
-      if key_info.is_list:
-        self.change_param_list(old_value, key_info, chosen_key)  # TODO: need to merge the code in this function with the below to reduce redundant code
+      if param_info.is_list:
+        self.change_param_list(old_value, param_info, chosen_key)  # TODO: need to merge the code in this function with the below to reduce redundant code
         return
 
       self.info('Current value: {} (type: {})'.format(old_value, type(old_value).__name__), sleep_time=0)
 
       while True:
-        self.prompt('\nEnter your new value or just press enter to exit:')
+        if param_info.live:
+          self.prompt('\nEnter your new value or [Enter] to exit:')
+        else:
+          self.prompt('\nEnter your new value:')
         new_value = input('>> ').strip()
         if new_value == '':
           self.info('Exiting this parameter...', 0.5)
           return
 
         new_value = self.str_eval(new_value)
-        if key_info.has_allowed_types and type(new_value) not in key_info.allowed_types:
+        if not param_info.is_valid(new_value):
           self.error('The type of data you entered ({}) is not allowed with this parameter!'.format(type(new_value).__name__))
           continue
 
-        if key_info.live:  # stay in live tuning interface
+        if param_info.live:  # stay in live tuning interface
           self.op_params.put(chosen_key, new_value)
           self.success('Saved {} with value: {}! (type: {})'.format(chosen_key, new_value, type(new_value).__name__))
         else:  # else ask to save and break
@@ -195,7 +198,7 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
             self.info('Not saved!', sleep_time=0)
           return
 
-  def change_param_list(self, old_value, key_info, chosen_key):
+  def change_param_list(self, old_value, param_info, chosen_key):
     while True:
       self.info('Current value: {} (type: {})'.format(old_value, type(old_value).__name__), sleep_time=0)
       self.prompt('\nEnter index to edit (0 to {}):'.format(len(old_value) - 1))
@@ -211,14 +214,14 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
       while True:
         self.info('Chosen index: {}'.format(choice_idx), sleep_time=0)
         self.info('Value: {} (type: {})'.format(old_value[choice_idx], type(old_value[choice_idx]).__name__), sleep_time=0)
-        self.prompt('\nEnter your new value or just press enter to exit:')
+        self.prompt('\nEnter your new value:')
         new_value = input('>> ').strip()
         if new_value == '':
           self.info('Exiting this list item...', 0.5)
           break
 
         new_value = self.str_eval(new_value)
-        if key_info.has_allowed_types and type(new_value) not in key_info.allowed_types:
+        if not param_info.is_valid(new_value):
           self.error('The type of data you entered ({}) is not allowed with this parameter!'.format(type(new_value).__name__))
           continue
 
@@ -256,32 +259,27 @@ class opEdit:  # use by running `python /data/openpilot/op_edit.py`
   def success(self, msg, sleep_time=None, end=''):
     if sleep_time is None:
       sleep_time = self.sleep_time
-    msg = self.str_color(msg, style='success', surround=False, underline=False)
+    msg = self.str_color(msg, style='success')
 
     print(msg, flush=True, end='\n' + end)
     time.sleep(sleep_time)
 
-  def str_color(self, msg, style, surround=False, underline=False):
+  def str_color(self, msg, style, surround=False):
     if style == 'success':
-      style = STYLES.SUCCESS
+      style = COLORS.SUCCESS
     elif style == 'fail':
-      style = STYLES.FAIL
+      style = COLORS.FAIL
     elif style == 'prompt':
-      style = STYLES.PROMPT
+      style = COLORS.PROMPT
     elif style == 'info':
-      style = STYLES.INFO
+      style = COLORS.INFO
     elif style == 'cyan':
-      style = STYLES.CYAN
-
-    if underline:
-      underline = STYLES.UNDERLINE
-    else:
-      underline = ''
+      style = COLORS.CYAN
 
     if surround:
-      msg = '{}--------\n{}{}\n{}--------{}'.format(style, underline, msg, STYLES.ENDC + style, STYLES.ENDC)
+      msg = '{}--------\n{}\n{}--------{}'.format(style, msg, COLORS.ENDC + style, COLORS.ENDC)
     else:
-      msg = '{}{}{}'.format(style + underline, msg, STYLES.ENDC)
+      msg = '{}{}{}'.format(style, msg, COLORS.ENDC)
 
     return msg
 

--- a/selfdrive/car/car_helpers.py
+++ b/selfdrive/car/car_helpers.py
@@ -16,7 +16,7 @@ from common.travis_checker import travis
 from common.op_params import opParams
 
 op_params = opParams()
-use_car_caching = op_params.get('use_car_caching', True)
+use_car_caching = op_params.get('use_car_caching')
 
 from cereal import car, log
 EventName = car.CarEvent.EventName

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -27,7 +27,7 @@ class CarInterfaceBase():
     self.disengage_due_to_slow_speed = False
     self.sm = messaging.SubMaster(['pathPlan'])
     self.op_params = opParams()
-    self.alca_min_speed = self.op_params.get('alca_min_speed', default=20.0)
+    self.alca_min_speed = self.op_params.get('alca_min_speed')
     self.CP = CP
     self.VM = VehicleModel(CP)
 

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -13,7 +13,7 @@ from common.op_params import opParams
 
 op_params = opParams()
 
-ludicrous_mode = op_params.get('ludicrous_mode', False)
+ludicrous_mode = op_params.get('ludicrous_mode')
 
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 
@@ -96,7 +96,7 @@ class CarController():
     #if self.sm.updated['pathPlan']:
     #  blinker = CS.out.leftBlinker or CS.out.rightBlinker
     #  ldw_allowed = CS.out.vEgo > 12.5 and not blinker
-    #  CAMERA_OFFSET = op_params.get('camera_offset', 0.06)
+    #  CAMERA_OFFSET = op_params.get('camera_offset')
     #  right_lane_visible = self.sm['pathPlan'].rProb > 0.5
     #  left_lane_visible = self.sm['pathPlan'].lProb > 0.5
     #  self.rightLaneDepart = bool(ldw_allowed and self.sm['pathPlan'].rPoly[3] > -(0.93 + CAMERA_OFFSET) and right_lane_visible)

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -14,8 +14,8 @@ from selfdrive.car.toyota.values import CAR, DBC, STEER_THRESHOLD, TSS2_CAR, NO_
 from common.op_params import opParams
 
 op_params = opParams()
-rsa_max_speed = op_params.get('rsa_max_speed', 24.5)
-limit_rsa = op_params.get('limit_rsa', False)
+rsa_max_speed = op_params.get('rsa_max_speed')
+limit_rsa = op_params.get('limit_rsa')
 
 class CarState(CarStateBase):
   def __init__(self, CP):

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -8,7 +8,7 @@ from selfdrive.car.interfaces import CarInterfaceBase
 from common.op_params import opParams
 
 op_params = opParams()
-spairrowtuning = op_params.get('spairrowtuning', False)
+spairrowtuning = op_params.get('spairrowtuning')
 
 GearShifter = car.CarState.GearShifter
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -69,8 +69,8 @@ class Controls:
 
     self.op_params = opParams()
     self.df_manager = dfManager(self.op_params)
-    self.hide_auto_df_alerts = self.op_params.get('hide_auto_df_alerts', False)
-    self.traffic_light_alerts = self.op_params.get('traffic_light_alerts', True)
+    self.hide_auto_df_alerts = self.op_params.get('hide_auto_df_alerts')
+    self.traffic_light_alerts = self.op_params.get('traffic_light_alerts')
     self.last_model_long = False
 
     self.can_sock = can_sock

--- a/selfdrive/controls/df_alert_manager.py
+++ b/selfdrive/controls/df_alert_manager.py
@@ -1,7 +1,7 @@
 class DfAlertManager:
   def __init__(self, op_params):
     self.op_params = op_params
-    self.current_profile = self.op_params.get('dynamic_follow', default='normal').lower()
+    self.current_profile = self.op_params.get('dynamic_follow').lower()
     self.profiles = ['close', 'normal', 'far']
 
     self.idx_to_profile = {0: 'close', 1: 'normal', 2: 'far'}

--- a/selfdrive/controls/lib/dynamic_follow/__init__.py
+++ b/selfdrive/controls/lib/dynamic_follow/__init__.py
@@ -321,11 +321,11 @@ class DynamicFollow:
     self.car_data.cruise_enabled = CS.cruiseState.enabled
 
   def _get_live_params(self):
-    self.global_df_mod = self.op_params.get('global_df_mod', None)
+    self.global_df_mod = self.op_params.get('global_df_mod')
     if self.global_df_mod is not None:
       self.global_df_mod = np.clip(self.global_df_mod, 0.85, 1.2)
 
-    self.min_TR = self.op_params.get('min_TR', None)
+    self.min_TR = self.op_params.get('min_TR')
     if self.min_TR is not None:
       self.min_TR = clip(self.min_TR, 0.85, 1.3)
     else:

--- a/selfdrive/controls/lib/dynamic_follow/df_manager.py
+++ b/selfdrive/controls/lib/dynamic_follow/df_manager.py
@@ -20,7 +20,7 @@ class dfManager:
     self.df_profiles = dfProfiles()
     self.sm = messaging_arne.SubMaster(['dynamicFollowButton', 'dynamicFollowData'])
 
-    self.cur_user_profile = self.op_params.get('dynamic_follow', default='normal').strip().lower()
+    self.cur_user_profile = self.op_params.get('dynamic_follow').strip().lower()
     if not isinstance(self.cur_user_profile, str) or self.cur_user_profile not in self.df_profiles.to_idx:
       self.cur_user_profile = self.df_profiles.normal  # relaxed
     else:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -81,7 +81,7 @@ class LanePlanner():
       self.r_lane_change_prob = md.meta.desireState[log.PathPlan.Desire.laneChangeRight - 1]
 
   def update_d_poly(self, v_ego):
-    CAMERA_OFFSET = op_params.get('camera_offset', 0.06)
+    CAMERA_OFFSET = op_params.get('camera_offset')
     # only offset left and right lane lines; offsetting p_poly does not make sense
     self.l_poly[3] += CAMERA_OFFSET
     self.r_poly[3] += CAMERA_OFFSET
@@ -89,7 +89,7 @@ class LanePlanner():
     # Find current lanewidth
     self.lane_width_certainty += 0.05 * (self.l_prob * self.r_prob - self.lane_width_certainty)
     current_lane_width = abs(self.l_poly[3] - self.r_poly[3])
-    if op_params.get('use_virtual_middle_line', False) and v_ego < 14.15:
+    if op_params.get('use_virtual_middle_line') and v_ego < 14.15:
       #lane_width = self.lane_width
       #print(current_lane_width)
       if current_lane_width < 2.0:

--- a/selfdrive/controls/lib/pathplanner.py
+++ b/selfdrive/controls/lib/pathplanner.py
@@ -66,8 +66,8 @@ class PathPlanner():
     self.blindspotTrueCounterleft = 0
     self.blindspotTrueCounterright = 0
     self.op_params = opParams()
-    self.alca_nudge_required = self.op_params.get('alca_nudge_required', default=True)
-    self.alca_min_speed = self.op_params.get('alca_min_speed', default=20.0)
+    self.alca_nudge_required = self.op_params.get('alca_nudge_required')
+    self.alca_min_speed = self.op_params.get('alca_min_speed')
 
   def setup_mpc(self):
     self.libmpc = libmpc_py.libmpc

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -20,14 +20,14 @@ from selfdrive.controls.lib.long_mpc_model import LongitudinalMpcModel
 from common.travis_checker import travis
 from common.op_params import opParams
 op_params = opParams()
-osm = op_params.get('osm', True)
-smart_speed = op_params.get('smart_speed', True)
-smart_speed_max_vego = op_params.get('smart_speed_max_vego', default=26.8)
-offset_limit = op_params.get('offset_limit', default=0.0)
-default_brake_distance = op_params.get('default_brake_distance', default=250.0)
+osm = op_params.get('osm')
+smart_speed = op_params.get('smart_speed')
+smart_speed_max_vego = op_params.get('smart_speed_max_vego')
+offset_limit = op_params.get('offset_limit')
+default_brake_distance = op_params.get('default_brake_distance')
 
 if not travis:
-  curvature_factor = opParams().get('curvature_factor', default=1.2)
+  curvature_factor = opParams().get('curvature_factor')
 else:
   curvature_factor = 1.0
 
@@ -133,7 +133,7 @@ class Planner():
   def choose_solution(self, v_cruise_setpoint, enabled, lead_1, lead_2, steeringAngle, model_enabled):
     center_x = -2.5 # Wheel base 2.5m
     lead1_check = True
-    mpc_offset = opParams().get('mpc_offset', default=0.0)
+    mpc_offset = opParams().get('mpc_offset')
     lead2_check = True
     if steeringAngle > 100: # only at high angles
       center_y = -1+2.5/math.tan(steeringAngle/1800.*math.pi) # Car Width 2m. Left side considered in left hand turn
@@ -189,7 +189,7 @@ class Planner():
     # we read offset value every 5 seconds
     fixed_offset = 0.0
     if not travis:
-      fixed_offset = op_params.get('speed_offset', 0.0)
+      fixed_offset = op_params.get('speed_offset')
       if self.last_time > 5:
         try:
           self.offset = int(self.params.get("SpeedLimitOffset", encoding='utf8'))

--- a/selfdrive/crash.py
+++ b/selfdrive/crash.py
@@ -70,8 +70,8 @@ else:
   except:
     ipaddress = "255.255.255.255"
   error_tags = {'dirty': dirty, 'dongle_id': dongle_id, 'branch': branch, 'remote': origin, 'distance_traveled': distance_traveled, 'distance_traveled_engaged': distance_traveled_engaged, 'distance_traveled_override': distance_traveled_override}
-  #uniqueID = op_params.get('uniqueID', None)
-  username = opParams().get('username', None)
+  #uniqueID = op_params.get('uniqueID')
+  username = opParams().get('username')
   if username is None or not isinstance(username, str):
     username = 'undefined'
   error_tags['username'] = username

--- a/selfdrive/data_collection/gps_uploader.py
+++ b/selfdrive/data_collection/gps_uploader.py
@@ -6,7 +6,7 @@ import os
 from common.params import Params
 from common.op_params import opParams
 op_params = opParams()
-uniqueID = op_params.get('uniqueID', None)
+uniqueID = op_params.get('uniqueID')
 
 def upload_data():
   filepath = "/data/openpilot/selfdrive/data_collection/gps-data"
@@ -14,7 +14,7 @@ def upload_data():
     if uniqueID is None:
       op_params.put('uniqueID', ''.join([random.choice(string.ascii_lowercase+string.ascii_uppercase+string.digits) for i in range(15)]))
     try:
-      username = op_params.get('uniqueID', None)
+      username = op_params.get('uniqueID')
       try:
         with open("/data/data/ai.comma.plus.offroad/files/persistStore/persist-auth", "r") as f:
           auth = json.loads(f.read())

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -16,7 +16,7 @@ from common.android import ANDROID
 from common.op_params import opParams
 op_params = opParams()
 
-traffic_lights = op_params.get('traffic_lights', False)
+traffic_lights = op_params.get('traffic_lights')
 
 WEBCAM = os.getenv("WEBCAM") is not None
 sys.path.append(os.path.join(BASEDIR, "pyextra"))

--- a/selfdrive/mapd/mapd_helpers.py
+++ b/selfdrive/mapd/mapd_helpers.py
@@ -12,9 +12,9 @@ MAPS_LOOKAHEAD_DISTANCE = 50 * LOOKAHEAD_TIME
 
 op_params = opParams()
 
-traffic_lights = op_params.get('traffic_lights', True)
-traffic_lights_without_direction = op_params.get('traffic_lights_without_direction', False)
-rolling_stop = op_params.get('rolling_stop', False)
+traffic_lights = op_params.get('traffic_lights')
+traffic_lights_without_direction = op_params.get('traffic_lights_without_direction')
+rolling_stop = op_params.get('rolling_stop')
 
 DEFAULT_SPEEDS_JSON_FILE = BASEDIR + "/selfdrive/mapd/default_speeds.json"
 DEFAULT_SPEEDS = {}

--- a/selfdrive/monitoring/driver_monitor.py
+++ b/selfdrive/monitoring/driver_monitor.py
@@ -10,7 +10,7 @@ from cereal import car
 EventName = car.CarEvent.EventName
 
 if not travis:
-  awareness_factor = opParams().get('awareness_factor', default=1.0)
+  awareness_factor = opParams().get('awareness_factor')
 else:
   awareness_factor = 1
 

--- a/selfdrive/monitoring/steering_monitor.py
+++ b/selfdrive/monitoring/steering_monitor.py
@@ -8,7 +8,7 @@ from cereal import car
 from common.op_params import opParams
 from common.travis_checker import travis
 if not travis:
-  awareness_factor = opParams().get('awareness_factor', default=1.0)
+  awareness_factor = opParams().get('awareness_factor')
 else:
   awareness_factor = 1
 

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -51,7 +51,7 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 NICE_LOW_PRIORITY = ["nice", "-n", "19"]
 SHORT = os.getenv("SHORT") is not None
 
-auto_update = opParams().get('autoUpdate', True) if not travis else False
+auto_update = opParams().get('autoUpdate') if not travis else False
 
 # Workaround for the EON/termux build of Python having os.link removed.
 ffi = FFI()

--- a/selfdrive/version.py
+++ b/selfdrive/version.py
@@ -5,7 +5,7 @@ from selfdrive.swaglog import cloudlog
 from common.op_params import opParams
 from common.travis_checker import travis
 
-cloak = opParams().get('cloak', True) if not travis else True
+cloak = opParams().get('cloak') if not travis else True
 
 def get_git_commit(default=None):
   if cloak:


### PR DESCRIPTION
- New way to specify params
- default is unsupported for getting params, it now gets the default from default_params
- Getting params not specified in fork_params will throw an exception, since it would have anyway if you forgot to specify default= in .get()