### PR TITLE
CAR.AVALON_2021 engine f/w should be 0x700

### DIFF
--- a/selfdrive/car/toyota/values.py
+++ b/selfdrive/car/toyota/values.py
@@ -239,7 +239,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x7a1, None): [
       b'8965B41090\x00\x00\x00\x00\x00\x00',
     ],
-    (Ecu.engine, 0x7e0, None): [
+    (Ecu.engine, 0x700, None): [
       b'\x01896630738000\x00\x00\x00\x00',
     ],
     (Ecu.fwdRadar, 0x750, 0xf): [


### PR DESCRIPTION


      ( ecu = engine,
        fwVersion = "\x01896630738000\x00\x00\x00\x00",
        address = 1792,
        subAddress = 0 ),
...that's 0x700 (dec)

## discription
Please make a PR against the dev branch usually called something like 077-clean then remove this sentence and add a discription
