### PR TITLE
Fix for model lag and trafficd only on when needed

### DIFF
--- a/common/op_params.py
+++ b/common/op_params.py
@@ -104,7 +104,7 @@ class opParams:
                         'prius_pid': Param(False, bool, 'This enables the PID lateral controller with new a experimental derivative tune\nFalse: stock INDI, True: TSS2-tuned PID'),
                         'physical_buttons_AP': Param(False, bool, 'This enables the physical buttons to control sport and eco, some cars do not have buttons'),
                         'physical_buttons_DF': Param(False, bool, 'This enables the physical buttons to control following distance, TSS1 works with new SDSU FW'),
-                        'physical_buttons_LKAS': Param(False, bool, 'This enables the physical buttons to control LKAS'),
+                        'physical_buttons_LKAS': Param(False, bool, 'This enables the physical buttons to control LKAS. TSS1 only this may break if used on TSS2 vechicle'),
                         'rolling_stop': Param(False, bool, 'If you do not want stop signs to go down to 0 kph enable this for 9kph slow down'),
                         'rsa_max_speed': Param(24.5, VT.number, 'Speed limit to ignore RSA in m/s'),
                         'set_speed_offset': Param(True, bool, 'Whether to use Set Speed offset from release4, enables low set speed and jump by 5 kph. False is on'),

--- a/selfdrive/manager.py
+++ b/selfdrive/manager.py
@@ -184,7 +184,6 @@ ThermalStatus = cereal.log.ThermalData.ThermalStatus
 # comment out anything you don't want to run
 managed_processes = {
   "thermald": "selfdrive.thermald.thermald",
-  "trafficd": ("selfdrive/trafficd", ["./trafficd"]),
   "traffic_manager": "selfdrive.trafficd.traffic_manager",
   "uploader": "selfdrive.loggerd.uploader",
   "deleter": "selfdrive.loggerd.deleter",
@@ -286,7 +285,6 @@ driver_view_processes = [
 
 if traffic_lights:
   car_started_processes += [
-    'trafficd',
     'traffic_manager',
   ]
   

--- a/selfdrive/mapd/mapd.py
+++ b/selfdrive/mapd/mapd.py
@@ -16,6 +16,7 @@ import logging.handlers
 from scipy import spatial
 import selfdrive.crash as crash
 from common.params import Params
+from common.basedir import BASEDIR
 from collections import defaultdict
 from multiprocessing import Process
 import cereal.messaging as messaging

--- a/selfdrive/trafficd/traffic_manager.py
+++ b/selfdrive/trafficd/traffic_manager.py
@@ -1,10 +1,36 @@
 #!/usr/bin/env python3
 
 from common.numpy_fast import clip
+from common.basedir import BASEDIR
+from common.realtime import sec_since_boot
 import cereal.messaging as messaging
 import numpy as np
 import time
-from common.realtime import sec_since_boot
+import subprocess
+import os
+import signal
+
+
+class TrafficdThread:
+  def __init__(self):
+    self.proc_path = 'selfdrive/trafficd/trafficd'
+    self.proc = None
+    self.started = False
+
+  def start(self):
+    if not self.started:
+      self.proc = subprocess.Popen(os.path.join(BASEDIR, self.proc_path), cwd=os.path.join(BASEDIR, os.path.dirname(self.proc_path)))
+      self.started = True
+    else:
+      print('trafficd already started')
+
+  def stop(self):
+    if self.proc is not None and self.started:
+      self.proc.send_signal(signal.SIGINT)
+      self.started = False
+    else:
+      print('trafficd not started, can\'t stop')
+
 
 
 class Traffic:

--- a/selfdrive/trafficd/traffic_manager.py
+++ b/selfdrive/trafficd/traffic_manager.py
@@ -21,6 +21,7 @@ class TrafficdThread:
     if not self.running:
       self.proc = subprocess.Popen(os.path.join(BASEDIR, self.proc_path), cwd=os.path.join(BASEDIR, os.path.dirname(self.proc_path)))
       self.running = True
+      print('trafficd starting')
     else:
       print('trafficd already running')
 
@@ -28,6 +29,7 @@ class TrafficdThread:
     if self.proc is not None and self.running:
       self.proc.send_signal(signal.SIGINT)
       self.running = False
+      print('trafficd stopped')
     else:
       print('trafficd not running, can\'t stop')
 
@@ -39,7 +41,7 @@ class Traffic:
     self.sm = messaging.SubMaster(['trafficModelRaw'])
 
     self.labels = ['SLOW', 'GREEN', 'NONE']
-    self.model_rate = 1 / 5.
+    self.model_rate = 1 / 3.
     self.recurrent_length = 1.  # in seconds, how far back to factor into current prediction
     self.min_preds = int(round(self.recurrent_length / self.model_rate))
     self.last_pred_weight = 5.  # places nx weight on most recent prediction
@@ -72,7 +74,7 @@ class Traffic:
         if not self.shown_dead_warning and self.last_log['log'] != 0:
           self.send_prediction('DEAD', 1.0)  # only show once
           self.shown_dead_warning = True
-        print("No response from trafficd in {} seconds. Is it dead?".format(round(sec_since_boot() - self.last_log['time'], 2)))
+          print("No response from trafficd in {} seconds. Is it dead?".format(round(sec_since_boot() - self.last_log['time'], 2)))
         time.sleep(0.5)
 
   def is_new_msg(self):

--- a/selfdrive/trafficd/traffic_manager.py
+++ b/selfdrive/trafficd/traffic_manager.py
@@ -15,21 +15,21 @@ class TrafficdThread:
   def __init__(self):
     self.proc_path = 'selfdrive/trafficd/trafficd'
     self.proc = None
-    self.started = False
+    self.running = False
 
   def start(self):
-    if not self.started:
+    if not self.running:
       self.proc = subprocess.Popen(os.path.join(BASEDIR, self.proc_path), cwd=os.path.join(BASEDIR, os.path.dirname(self.proc_path)))
-      self.started = True
+      self.running = True
     else:
-      print('trafficd already started')
+      print('trafficd already running')
 
   def stop(self):
-    if self.proc is not None and self.started:
+    if self.proc is not None and self.running:
       self.proc.send_signal(signal.SIGINT)
-      self.started = False
+      self.running = False
     else:
-      print('trafficd not started, can\'t stop')
+      print('trafficd not running, can\'t stop')
 
 
 

--- a/selfdrive/trafficd/trafficd.cc
+++ b/selfdrive/trafficd/trafficd.cc
@@ -10,7 +10,7 @@ volatile sig_atomic_t do_exit = 0;
 
 const std::vector<std::string> modelLabels = {"SLOW", "GREEN", "NONE"};
 const int numLabels = modelLabels.size();
-const double modelRate = 1 / 5.;  // 5 Hz
+const double modelRate = 1 / 3.;  // 3 Hz
 const bool debug_mode = false;
 
 const int original_shape[3] = {874, 1164, 3};   // global constants


### PR DESCRIPTION
Having trafficd at 5 Hz is too much. this causes system lag and 3Hz is fine enough.
When in the 4km radius circle of map data downloaded a traffic light or a rail crossing occurs then trafficd is loaded and if there is none then it will shut down trafficd to save resources.